### PR TITLE
Replace 'is not' with '!=' to compare integers.

### DIFF
--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -114,7 +114,7 @@ class Variable(object):
 
         lenvar = len(self.values)
         lenunc = len(uncertainty.values)
-        if lenvar and (lenvar is not lenunc):
+        if lenvar and (lenvar != lenunc):
             raise ValueError("Length of uncertainty list ({0})" \
                              "is not the same as length of Variable" \
                              "values list ({1})!.".format(lenunc, lenvar))


### PR DESCRIPTION
I only found one case where we use `is not`, when we shouldn't. There are some cases where we use something like `is not None`, but as far as I understand, that is fine.


Closes #79 
