### PR TITLE
Improve variable constructor

### DIFF
--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -53,7 +53,8 @@ class Variable(object):
     # pylint: disable=too-many-instance-attributes
     # Eight is reasonable in this case.
 
-    def __init__(self, name, is_independent=True, is_binned=True, units="", values=[]):
+    def __init__(self, name, is_independent=True, is_binned=True, units="", values=None):
+        # pylint: disable=too-many-arguments
         self.name = name
         self.is_independent = is_independent
         self.is_binned = is_binned
@@ -61,7 +62,7 @@ class Variable(object):
         self.units = units
         # needed to make pylint happy, see https://github.com/PyCQA/pylint/issues/409
         self._values = None
-        self.values = values
+        self.values = values if values else []
         self.uncertainties = []
         self.digits = 5
 
@@ -76,9 +77,11 @@ class Variable(object):
         if self.is_binned:
             # Check that the input is well-formed
             try:
-                assert(all([len(x)==2 for x in value_list ]))
+                assert all([len(x) == 2 for x in value_list])
             except (TypeError, ValueError):
-                raise ValueError("For binned Variables, values should be tuples of length two: (lower bin edge, upper bin edge).")
+                raise ValueError("For binned Variables, values should be tuples of length two: \
+                                 (lower bin edge, upper bin edge)."
+                                )
 
             # All good
             self._values = [(float(x[0]), float(x[1])) for x in value_list]

--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -78,7 +78,7 @@ class Variable(object):
             # Check that the input is well-formed
             try:
                 assert all([len(x) == 2 for x in value_list])
-            except (TypeError, ValueError):
+            except (AssertionError, TypeError, ValueError):
                 raise ValueError("For binned Variables, values should be tuples of length two: \
                                  (lower bin edge, upper bin edge)."
                                 )

--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -53,7 +53,7 @@ class Variable(object):
     # pylint: disable=too-many-instance-attributes
     # Eight is reasonable in this case.
 
-    def __init__(self, name, is_independent=True, is_binned=True, units=""):
+    def __init__(self, name, is_independent=True, is_binned=True, units="", values=[]):
         self.name = name
         self.is_independent = is_independent
         self.is_binned = is_binned
@@ -61,7 +61,7 @@ class Variable(object):
         self.units = units
         # needed to make pylint happy, see https://github.com/PyCQA/pylint/issues/409
         self._values = None
-        self.values = []
+        self.values = values
         self.uncertainties = []
         self.digits = 5
 
@@ -74,9 +74,21 @@ class Variable(object):
     def values(self, value_list):
         """Value Setter."""
         if self.is_binned:
+            # Check that the input is well-formed
+            try:
+                assert(all([len(x)==2 for x in value_list ]))
+            except (TypeError, ValueError):
+                raise ValueError("For binned Variables, values should be tuples of length two: (lower bin edge, upper bin edge).")
+
+            # All good
             self._values = [(float(x[0]), float(x[1])) for x in value_list]
         else:
-            self._values = [x if isinstance(x, str) else float(x) for x in value_list]
+            # Check that the input is well-formed
+            try:
+                parsed_values = [x if isinstance(x, str) else float(x) for x in value_list]
+            except (TypeError, ValueError):
+                raise ValueError("Malformed input for unbinned variable: ", value_list)
+            self._values = parsed_values
 
     def scale_values(self, factor):
         """Multiply each value by constant factor. Also applies to uncertainties."""

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -139,9 +139,19 @@ class TestVariable(TestCase):
 
         binned_values = [(1,2),(2,3),(3,4)]
         unbinned_values = [1,2,3,4]
+        binned_values_wrong_length = [(1,2,3),(4,5,6)]
 
-        # Should work fine
-        var = Variable("testvar", is_binned=True, values=binned_values)
+        # Should work fine: Binned
+        try:
+            var = Variable("testvar", is_binned=True, values=binned_values)
+        except ValueError:
+            self.fail("Variable constructor raised unexpected ValueError.")
+
+        # Should work fine: Unbinned
+        try:
+            var = Variable("testvar", is_binned=False, values=unbinned_values)
+        except ValueError:
+            self.fail("Variable constructor raised unexpected ValueError.")
 
         # Wrong type of argument
         with self.assertRaises(ValueError):
@@ -150,3 +160,7 @@ class TestVariable(TestCase):
         # Other way around
         with self.assertRaises(ValueError):
             var = Variable("testvar", is_binned=False, values=binned_values)
+
+        # Tuples, but wrong length
+        with self.assertRaises(ValueError):
+            var = Variable("testvar", is_binned=False, values=binned_values_wrong_length)

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -103,12 +103,12 @@ class TestVariable(TestCase):
         # With or without units
         for units in ["", "GeV"]:
             var.units = units
-            
+
             # Binned
             var.is_binned = False
             var.values = [1,2,3]
             var.make_dict()
-            
+
             # Unbinned
             var.is_binned = True
             var.values = [(0,1), (1,2), (2,3)]
@@ -133,3 +133,20 @@ class TestVariable(TestCase):
         var.add_qualifier("testqualifier1", 1, units="GeV")
         var.add_qualifier("testqualifier2", 1, units="")
         var.make_dict()
+
+    def test_constructor(self):
+        """Test the constructor of the Variable class."""
+
+        binned_values = [(1,2),(2,3),(3,4)]
+        unbinned_values = [1,2,3,4]
+
+        # Should work fine
+        var = Variable("testvar", is_binned=True, values=binned_values)
+
+        # Wrong type of argument
+        with self.assertRaises(ValueError):
+            var = Variable("testvar", is_binned=True, values=unbinned_values)
+
+        # Other way around
+        with self.assertRaises(ValueError):
+            var = Variable("testvar", is_binned=False, values=binned_values)


### PR DESCRIPTION
The `values` property can now be set from the constructor, like:

``var = Variable("name", is_binned=False, values=[1,2,3])``

Additionally, the `values` setter now checks that the input format agrees with the `is_binned` property. If a Variable is binned, the input should be a list of two-valued tuples. If it is not, it should be parse-able into a list of single values.