### PR TITLE
Limit the length of table names to 64 characters.

### DIFF
--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -203,7 +203,10 @@ class Table(object):
     the location within the paper, etc.
     """
 
+    # pylint: disable=too-many-instance-attributes
+
     def __init__(self, name):
+        self._name = None
         self.name = name
         self.variables = []
         self.description = "Example description"
@@ -211,6 +214,18 @@ class Table(object):
         self.keywords = {}
         self.additional_resources = []
         self.image_files = set([])
+
+    @property
+    def name(self):
+        """Name getter."""
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        """Name setter."""
+        if len(name) > 64:
+            raise ValueError("Table name must not be longer than 64 characters.")
+        self._name = name
 
     def add_image(self, file_path, outdir=None):
         """

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -10,6 +10,30 @@ from hepdata_lib import Table, Variable, Uncertainty, helpers
 
 class TestTable(TestCase):
     """Test the Table class."""
+
+    def test_name_checks(self):
+        """Test the table name checks."""
+
+        # This should work fine
+        good_name = "64 characters or fewer"
+        try:
+            good_table = Table(good_name)
+        except ValueError:
+            self.fail("Table initializer raised unexpected ValueError.")
+
+        self.assertEqual(good_name, good_table.name)
+
+        # Check name that is too long
+        too_long_name = "x"*100
+
+        # In the initializer
+        with self.assertRaises(ValueError):
+            bad_table = Table(too_long_name)
+
+        # Using the setter
+        with self.assertRaises(ValueError):
+            good_table.name = too_long_name
+
     def test_add_variable(self):
         """Test the add_variable function."""
 


### PR DESCRIPTION
Closes #34 