### PR TITLE
Add .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,23 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
This is an attempt to fix the build errors for the docs.
Documentation for this file: https://docs.readthedocs.io/en/stable/config-file/v2.html

I actually realised that also just changing the CPython version from 2.X to 3.X in the settings fixes the issue, but with this config we should be on the safe side.

Build successful: https://readthedocs.org/projects/hepdata-lib/builds/