### PR TITLE
Fixed release.yml for protected branches and updated docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@master
+        with:
+          persist-credentials: false
+
         # Check for permissions
       - uses: scherermichael/action-has-permission@master
         id: check
@@ -48,7 +51,7 @@ jobs:
         if: steps.check.outputs.has-permission
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.access_token }}
           tags: true
           branch: master
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -78,4 +78,4 @@ Opening an new issue automatically creates a new release if:
 - The title of the issue starts with the word "release" (not case-sensitive).
 - The body of the issue contains only one of the following words: "patch", "minor" or "major".
 
-Remember to set the following github secrets: "test_pypi_password" and "pypi_password". This also uses the API token feature of PyPI.
+Remember to set the following github secrets: "test_pypi_password" , "pypi_password" and your personal access token to "access_token". This also uses the API token feature of PyPI.


### PR DESCRIPTION
- Changed push action to use personal access token and updated docs.