### PR TITLE
Fix macOS tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,18 +26,14 @@ jobs:
       - uses: actions/checkout@v2
       - name: Test with pytest
         run: |
+          ROOT_VERSION=6.20.04_1
           brew update
-          brew install root
-          # brew cask uninstall --force oclint
-          # brew upgrade python cmake libpng libtiff
-          # brew install --force ossp-uuid davix fftw fontconfig gd graphviz gsl lz4 tbb xrootd
-          # curl -O https://clange.web.cern.ch/clange/root-v6.18.00.tar.gz
-          # tar xzf root-v6.18.00.tar.gz
-          # mkdir -p /usr/local/Cellar/root
-          # mv 6.18.00 /usr/local/Cellar/root/
-          ROOT_CELLAR=$(brew --cellar root)
-          ROOT_PATH=${ROOT_CELLAR}/$(ls ${ROOT_CELLAR})
-          cd ${ROOT_PATH}
+          brew install fontconfig gd gettext libffi glib jasper netpbm gts graphviz gsl libxml2 openblas numpy tbb xrootd
+          curl -O https://clange.web.cern.ch/clange/root-v${ROOT_VERSION}.tar.gz
+          tar xzf root-v${ROOT_VERSION}.tar.gz
+          mkdir -p /usr/local/Cellar/root
+          mv ${ROOT_VERSION} /usr/local/Cellar/root/
+          cd /usr/local/Cellar/root/${ROOT_VERSION}
           export PATH=${PWD}/bin:${PATH}
           export PYTHONPATH=${PWD}/lib/root:${PYTHONPATH}
           export LD_LIBRARY_PATH=${PWD}/lib/root:${LD_LIBRARY_PATH}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
           mkdir -p /usr/local/Cellar/root
           mv ${ROOT_VERSION} /usr/local/Cellar/root/
           cd /usr/local/Cellar/root/${ROOT_VERSION}
-          export PATH=${PWD}/bin:${PATH}
+          export PATH=${PWD}/bin:$(brew --cellar python@3.8)/$(ls $(brew --cellar python@3.8))/bin:${PATH}
           export PYTHONPATH=${PWD}/lib/root:${PYTHONPATH}
           export LD_LIBRARY_PATH=${PWD}/lib/root:${LD_LIBRARY_PATH}
           echo ${PYTHONPATH}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,8 @@ jobs:
         run: |
           ROOT_VERSION=6.20.04_1
           brew update
-          brew install --force fontconfig gd gettext libffi glib jasper netpbm gts graphviz gsl libxml2 openblas numpy tbb xrootd
+          brew upgrade python cmake libpng libtiff
+          brew install fontconfig gd gettext libffi glib jasper netpbm gts graphviz gsl libxml2 openblas numpy tbb xrootd || true
           curl -O https://clange.web.cern.ch/clange/root-v${ROOT_VERSION}.tar.gz
           tar xzf root-v${ROOT_VERSION}.tar.gz
           mkdir -p /usr/local/Cellar/root

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           ROOT_VERSION=6.20.04_1
           brew update
-          brew install fontconfig gd gettext libffi glib jasper netpbm gts graphviz gsl libxml2 openblas numpy tbb xrootd
+          brew install --force fontconfig gd gettext libffi glib jasper netpbm gts graphviz gsl libxml2 openblas numpy tbb xrootd
           curl -O https://clange.web.cern.ch/clange/root-v${ROOT_VERSION}.tar.gz
           tar xzf root-v${ROOT_VERSION}.tar.gz
           mkdir -p /usr/local/Cellar/root

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: tests
 #Running tests on all branches
 on: [push,pull_request]
 
-jobs:  
+jobs:
   # This is a job for linux python3 tests
   linuxpy3:
       runs-on: [ubuntu-18.04]
@@ -13,7 +13,7 @@ jobs:
         - uses: actions/checkout@v2
         - name: Test with pytest
           run: |
-            yum install -y python-pip ghostscript 
+            yum install -y python-pip ghostscript
             python -m pip install pytest_pylint configparser astroid pyyml papermill
             python setup.py test
             python -m pylint hepdata_lib/*.py
@@ -27,14 +27,17 @@ jobs:
       - name: Test with pytest
         run: |
           brew update
-          brew cask uninstall --force oclint
-          brew upgrade python cmake libpng libtiff
-          brew install --force ossp-uuid davix fftw fontconfig gd graphviz gsl lz4 tbb xrootd
-          curl -O https://clange.web.cern.ch/clange/root-v6.18.00.tar.gz
-          tar xzf root-v6.18.00.tar.gz
-          mkdir -p /usr/local/Cellar/root
-          mv 6.18.00 /usr/local/Cellar/root/
-          cd /usr/local/Cellar/root/6.18.00
+          brew install root
+          # brew cask uninstall --force oclint
+          # brew upgrade python cmake libpng libtiff
+          # brew install --force ossp-uuid davix fftw fontconfig gd graphviz gsl lz4 tbb xrootd
+          # curl -O https://clange.web.cern.ch/clange/root-v6.18.00.tar.gz
+          # tar xzf root-v6.18.00.tar.gz
+          # mkdir -p /usr/local/Cellar/root
+          # mv 6.18.00 /usr/local/Cellar/root/
+          ROOT_CELLAR=$(brew --cellar root)
+          ROOT_PATH=${ROOT_CELLAR}/$(ls ${ROOT_CELLAR})
+          cd ${ROOT_PATH}
           export PATH=${PWD}/bin:${PATH}
           export PYTHONPATH=${PWD}/lib/root:${PYTHONPATH}
           export LD_LIBRARY_PATH=${PWD}/lib/root:${LD_LIBRARY_PATH}
@@ -45,7 +48,7 @@ jobs:
           python3 -m pip install -e .
           python3 -m pylint hepdata_lib/*.py
           python3 -m pylint tests/*.py --rcfile=tests/pylintrc
-  
+
  # This is a job for linux python2.7 tests
   linuxpy27:
     runs-on: ubuntu-16.04
@@ -64,7 +67,7 @@ jobs:
         sudo sed -i '/PDF/ a <policy domain="coder" rights="read|write" pattern="LABEL" />' /etc/ImageMagick-6/policy.xml
         python -m pip install --upgrade enum34 pytest_pylint configparser astroid future ipykernel papermill
         sudo apt update
-        sudo apt install -y ghostscript    
+        sudo apt install -y ghostscript
         source root/bin/thisroot.sh
         python setup.py test
         python -m pylint hepdata_lib/*.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,8 +28,8 @@ jobs:
         run: |
           ROOT_VERSION=6.20.04_1
           brew update
-          brew upgrade python cmake libpng libtiff
           brew install fontconfig gd gettext libffi glib jasper netpbm gts graphviz gsl libxml2 openblas numpy tbb xrootd || true
+          brew install python@3.8 openssl@1.1 || true
           curl -O https://clange.web.cern.ch/clange/root-v${ROOT_VERSION}.tar.gz
           tar xzf root-v${ROOT_VERSION}.tar.gz
           mkdir -p /usr/local/Cellar/root


### PR DESCRIPTION
The [homebrew ROOT formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/root.rb) uses `python@3.8` explicitly, so we need to do the same. Installing ROOT from source takes as in the past 45 minutes, so I chose to download a tar ball again.