### PR TITLE
Actions: Make sure to instlal hepdata_lib

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
           run: |
             yum install -y python-pip ghostscript
             python -m pip install pytest_pylint configparser astroid pyyml papermill
+            python -m pip install -e .
             python setup.py test
             python -m pylint hepdata_lib/*.py
             python -m pylint tests/*.py --rcfile=tests/pylintrc


### PR DESCRIPTION
I think this will fix the failing linuxpy3 tests.