### PR TITLE
Docs: fix m2r issue in Sphinx 3.3.0+

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -181,3 +181,20 @@ texinfo_documents = [
 
 # -- Extension configuration -------------------------------------------------
 autodoc_mock_imports = ["ROOT"]
+
+"""Patching m2r"""
+import m2r
+
+current_m2r_setup = m2r.setup
+
+def patched_m2r_setup(app):
+    try:
+        return current_m2r_setup(app)
+    except (AttributeError):
+        app.add_source_suffix(".md", "markdown")
+        app.add_source_parser(m2r.M2RParser)
+    return dict(
+        version=m2r.__version__, parallel_read_safe=True, parallel_write_safe=True,
+    )
+
+m2r.setup = patched_m2r_setup


### PR DESCRIPTION
fixes #138 
m2r generate an error in Sphinx >=3.3.0 failing build.
I backported to m2r a fix proposed here for m2r2:
https://github.com/sphinx-doc/sphinx/issues/8395#issuecomment-725355567
