### PR TITLE
Dockerfile: Make sure to use Fedora-based root container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rootproject/root:latest
+FROM rootproject/root:6.22.06-fedora33
 
 ENV MAGICK_HOME=/usr
 


### PR DESCRIPTION
The setup in the Dockerfile is based on the assumption that the base container is Fedora based. However, apparently root changed their tag structure, so 'latest' does not point to Fedora anymore. They still have specific Fedora tags and switching to that fixes the Docker build. @clelange please check if this makes sense to you