### PR TITLE
RootFileReader: Allow access to bin labels + small other improvements

### DIFF
--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -270,6 +270,7 @@ class Table(object):
 
         if not isinstance(file_path, str):
             raise TypeError("Expected string argument, instead got: '{}'.".format(type(file_path)))
+        file_path = os.path.expanduser(file_path)
         if os.path.exists(file_path):
             self.image_files.add(file_path)
         else:

--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -245,7 +245,7 @@ class Table(object):
     def name(self, name):
         """Name setter."""
         if len(name) > 64:
-            raise ValueError("Table name must not be longer than 64 characters.")
+            raise ValueError("Table name must not be longer than 64 characters: " + name)
         self._name = name
 
     def add_image(self, file_path, outdir=None):

--- a/hepdata_lib/root_utils.py
+++ b/hepdata_lib/root_utils.py
@@ -284,7 +284,7 @@ def get_hist_2d_points(hist, **kwargs):
         assert ylim[0] < ylim[1]
 
     points = {}
-    for key in ["x", "y", "x_edges", "y_edges", "z", "dz","x_labels","y_labels"]:
+    for key in ["x", "y", "x_edges", "y_edges", "z", "dz", "x_labels", "y_labels"]:
         points[key] = []
 
     ixmin = hist.GetXaxis().FindBin(xlim[0]) if xlim[0] is not None else 1

--- a/hepdata_lib/root_utils.py
+++ b/hepdata_lib/root_utils.py
@@ -284,7 +284,7 @@ def get_hist_2d_points(hist, **kwargs):
         assert ylim[0] < ylim[1]
 
     points = {}
-    for key in ["x", "y", "x_edges", "y_edges", "z", "dz"]:
+    for key in ["x", "y", "x_edges", "y_edges", "z", "dz","x_labels","y_labels"]:
         points[key] = []
 
     ixmin = hist.GetXaxis().FindBin(xlim[0]) if xlim[0] is not None else 1
@@ -317,6 +317,9 @@ def get_hist_2d_points(hist, **kwargs):
 
             points["z"].append(z_val)
             points["dz"].append(dz_val)
+
+            points["x_labels"].append(hist.GetXaxis().GetBinLabel(x_bin))
+            points["y_labels"].append(hist.GetYaxis().GetBinLabel(y_bin))
 
     return points
 
@@ -356,7 +359,7 @@ def get_hist_1d_points(hist, **kwargs):
         assert xlim[0] < xlim[1]
 
     points = {}
-    for key in ["x", "y", "x_edges", "dy"]:
+    for key in ["x", "y", "x_edges", "x_labels", "dy"]:
         points[key] = []
 
     symmetric = (hist.GetBinErrorOption() == r.TH1.kNormal)
@@ -379,6 +382,8 @@ def get_hist_1d_points(hist, **kwargs):
 
         points["y"].append(y_val)
         points["dy"].append(dy_val)
+
+        points["x_labels"].append(hist.GetXaxis().GetBinLabel(x_bin))
 
     return points
 

--- a/tests/test_rootfilereader.py
+++ b/tests/test_rootfilereader.py
@@ -388,7 +388,7 @@ class TestRootFileReader(TestCase):
 
         # Clean up
         self.doCleanups()
-    
+
     def test_read_hist_2d_bin_labels(self):
         """Test the read_hist_2d function with bin labels."""
         name = "test"

--- a/tests/test_rootfilereader.py
+++ b/tests/test_rootfilereader.py
@@ -184,9 +184,9 @@ class TestRootFileReader(TestCase):
             hist.SetBinContent(i, y_values[i-1])
             hist.SetBinError(i, dy_values[i-1])
 
-            c = hist.GetBinCenter(i)
-            w = hist.GetBinWidth(i)
-            x_edges.append((c-0.5*w, c+0.5*w))
+            center = hist.GetBinCenter(i)
+            width = hist.GetBinWidth(i)
+            x_edges.append((center-0.5*width, center+0.5*width))
 
         testfile = make_tmp_root_file(testcase=self)
         testfile.cd()
@@ -395,15 +395,15 @@ class TestRootFileReader(TestCase):
         name = "test"
 
         # Create test histogram
-        Nx = 13
-        Ny = 37
-        y_values = np.random.uniform(-1e3, 1e3, (Nx,Ny))
-        xlabels = ["X{0}".format(i) for i in range(Nx)]
-        ylabels = ["Y{0}".format(i) for i in range(Ny)]
+        NX = 13
+        NY = 37
+        y_values = np.random.uniform(-1e3, 1e3, (NX,NY))
+        xlabels = ["X{0}".format(i) for i in range(NX)]
+        ylabels = ["Y{0}".format(i) for i in range(NY)]
 
-        hist = ROOT.TH2D("test2d_labels", "test2d_labels", Nx, 0, Nx, Ny, 0, Ny)
-        for i in range(Nx):
-            for j in range(Ny):
+        hist = ROOT.TH2D("test2d_labels", "test2d_labels", NX, 0, NX, NY, 0, NY)
+        for i in range(NX):
+            for j in range(NY):
                 hist.Fill(i,j,y_values[i,j])
                 hist.GetXaxis().SetBinLabel(i+1, xlabels[i])
                 hist.GetYaxis().SetBinLabel(j+1, ylabels[j])
@@ -421,9 +421,9 @@ class TestRootFileReader(TestCase):
 
         # The output ordering is
         # [(x=0,y=0), (x=0,y=1), ...]
-        for i in range(Nx):
-            for j in range(Ny):
-                index = i*Ny + j
+        for i in range(NX):
+            for j in range(NY):
+                index = i*NY + j
                 self.assertTrue(
                     points["x_labels"][index]==xlabels[i]
                 )

--- a/tests/test_rootfilereader.py
+++ b/tests/test_rootfilereader.py
@@ -394,17 +394,18 @@ class TestRootFileReader(TestCase):
         name = "test"
 
         # Create test histogram
-        N = 20
-        y_values = np.random.uniform(-1e3, 1e3, (N,N))
-        xlabels = ["X{0}".format(i) for i in range(N)]
-        ylabels = ["Y{0}".format(i) for i in range(N)]
+        Nx = 13
+        Ny = 37
+        y_values = np.random.uniform(-1e3, 1e3, (Nx,Ny))
+        xlabels = ["X{0}".format(i) for i in range(Nx)]
+        ylabels = ["Y{0}".format(i) for i in range(Ny)]
 
-        hist = ROOT.TH2D("test2d_labels", "test2d_labels", N, 0, N, N, 0, N)
-        for i in range(hist.GetNbinsX()):
-            for j in range(hist.GetNbinsY()):
-                hist.Fill(N,N,y_values[i,j])
+        hist = ROOT.TH2D("test2d_labels", "test2d_labels", Nx, 0, Nx, Ny, 0, Ny)
+        for i in range(Nx):
+            for j in range(Ny):
+                hist.Fill(i,j,y_values[i,j])
                 hist.GetXaxis().SetBinLabel(i+1, xlabels[i])
-                hist.GetYaxis().SetBinLabel(j+1, ylabels[i])
+                hist.GetYaxis().SetBinLabel(j+1, ylabels[j])
 
         testfile = make_tmp_root_file(testcase=self)
         testfile.cd()
@@ -419,13 +420,15 @@ class TestRootFileReader(TestCase):
 
         # The output ordering is
         # [(x=0,y=0), (x=0,y=1), ...]
-        for i in range(N*N):
-            self.assertTrue(
-                points["x_labels"][i]==xlabels[i//N]
-            )
-            self.assertTrue(
-                points["y_labels"][i]==ylabels[j%N]
-            )
+        for i in range(Nx):
+            for j in range(Ny):
+                index = i*Ny + j
+                self.assertTrue(
+                    points["x_labels"][index]==xlabels[i]
+                )
+                self.assertTrue(
+                    points["y_labels"][index]==ylabels[j]
+                )
         # Clean up
         self.doCleanups()
 

--- a/tests/test_rootfilereader.py
+++ b/tests/test_rootfilereader.py
@@ -115,7 +115,7 @@ class TestRootFileReader(TestCase):
         data = reader.read_graph(name)
 
         # Check consistency
-        for key in ["x", "y", "dx","dy"]:
+        for key in ["x", "y", "dx", "dy"]:
             self.assertTrue(key in set(data.keys()))
         self.assertTrue(all(data["x"] == x))
         self.assertTrue(all(data["y"] == y))
@@ -132,7 +132,6 @@ class TestRootFileReader(TestCase):
         """
         # pylint: disable-msg=too-many-locals
         N = 20
-        _filepath = "testfile.root"
         name = "testgraph"
 
         x = np.random.uniform(-1e3, 1e3, N)
@@ -157,7 +156,7 @@ class TestRootFileReader(TestCase):
         data = reader.read_graph(name)
 
         # Check consistency
-        for key in ["x", "y", "dx","dy"]:
+        for key in ["x", "y", "dx", "dy"]:
             self.assertTrue(key in set(data.keys()))
 
         self.assertTrue(all(data["x"] == x))
@@ -269,8 +268,6 @@ class TestRootFileReader(TestCase):
 
     def test_read_hist_1d_asymmetric_errors(self):
         """Test the read_hist_1d function for a histogram with asymmetric errors."""
-        _fpath = "testfile.root"
-
         # Create test histogram
         n_bin = 17
         n_fill = 1000
@@ -465,7 +462,7 @@ class TestRootFileReader(TestCase):
         points = reader.read_hist_2d(testname)
 
         # Check keys
-        for key in ["x","y","z","dz"]:
+        for key in ["x", "y", "z", "dz"]:
             self.assertTrue(key in points.keys())
 
         # Check length
@@ -554,7 +551,7 @@ class TestRootFileReader(TestCase):
         points = reader.read_hist_2d(testname, xlim=(xmin, xmax), ylim=(ymin, ymax))
 
         # Check keys
-        for key in ["x","y","z","dz"]:
+        for key in ["x", "y", "z", "dz"]:
             self.assertTrue(key in points.keys())
 
         # Check length
@@ -610,7 +607,7 @@ class TestRootFileReader(TestCase):
         points = reader.read_hist_2d("test2d_asym")
 
         # Check keys
-        for key in ["x","y","z","dz"]:
+        for key in ["x", "y", "z", "dz"]:
             self.assertTrue(key in points.keys())
 
         # Check length
@@ -664,7 +661,7 @@ class TestRootFileReader(TestCase):
         points = reader.read_hist_2d("test2d_asym", force_symmetric_errors=True)
 
         # Check keys
-        for key in ["x","y","z","dz"]:
+        for key in ["x", "y", "z", "dz"]:
             self.assertTrue(key in points.keys())
 
         # Check length


### PR DESCRIPTION
The main change here is the addition of the ability to read bin labels from ROOT histogram. Tests of the functionality have been added, as well.
While implementing the tests, I realized that many test functions have unnecessarily strict checks of the reader output, which break if you add new keys. I took the opportunity to change these assertions to only check that the data needed for a specific check is present, rather than enforcing that no additional data is present.

I also made two small quality-of-life changes to `Table`.