### PR TITLE
Factor out additional resources, add to Table

### DIFF
--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -83,11 +83,11 @@ class AdditionalResourceMixin(object):
             helpers.check_file_existence(location)
             helpers.check_file_size(location, upper_limit=100)
             resource["location"] = os.path.basename(location)
+            self.files_to_copy.append(location)
         else:
             resource["location"] = location
 
         self.additional_resources.append(resource)
-        self.files_to_copy.append(location)
 
     def copy_files(self, outdir):
         """
@@ -450,6 +450,7 @@ class Submission(AdditionalResourceMixin):
         self.tables = []
         self.comment = ""
         self.record_ids = []
+        self.add_additional_resource("Created with hepdata_lib " + __version__, "https://zenodo.org/record/4946277")
 
     @staticmethod
     def get_license():

--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -49,6 +49,8 @@ warnings.filterwarnings("always", category=DeprecationWarning, module="hepdata_l
 __version__ = "0.5.0"
 
 class AdditionalResourceMixin(object):
+    """Functionality related to additional materials."""
+
     def __init__(self):
         self.files_to_copy = []
         self.additional_resources = []
@@ -280,7 +282,7 @@ class Table(AdditionalResourceMixin):
     # pylint: disable=too-many-instance-attributes
 
     def __init__(self, name):
-        super(Table, self).__init__()
+        super().__init__()
         self._name = None
         self.name = name
         self.variables = []
@@ -446,11 +448,13 @@ class Submission(AdditionalResourceMixin):
     """
 
     def __init__(self):
-        super(Submission, self).__init__()
+        super().__init__()
         self.tables = []
         self.comment = ""
         self.record_ids = []
-        self.add_additional_resource("Created with hepdata_lib " + __version__, "https://zenodo.org/record/4946277")
+        self.add_additional_resource(
+            "Created with hepdata_lib " + __version__,
+            "https://zenodo.org/record/4946277")
 
     @staticmethod
     def get_license():

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -131,3 +131,17 @@ class TestTable(TestCase):
             test_table.add_additional_resource("some link","www.cern.ch")
         except:
             self.fail("Table.add_additional_resource raised an unexpected exception.")
+
+    def test_copy_files(self):
+        """Test the copy_files function."""
+        test_table = Table("Some Table")
+        some_pdf = "%s/minimal.pdf" % os.path.dirname(__file__)
+        testdir = "test_output"
+        self.addCleanup(shutil.rmtree, testdir)
+        os.makedirs(testdir)
+
+        test_table.add_additional_resource("a plot",some_pdf, copy_file=True)
+        try:
+            test_table.copy_files(testdir)
+        except:
+            self.fail("Table.copy_files raised an unexpected exception.")

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -127,10 +127,7 @@ class TestTable(TestCase):
     def test_add_additional_resource(self):
         """Test the add_additional_resource function."""
         test_table = Table("Some Table")
-        try:
-            test_table.add_additional_resource("some link","www.cern.ch")
-        except:
-            self.fail("Table.add_additional_resource raised an unexpected exception.")
+        test_table.add_additional_resource("some link","www.cern.ch")
 
     def test_copy_files(self):
         """Test the copy_files function."""
@@ -141,7 +138,5 @@ class TestTable(TestCase):
         os.makedirs(testdir)
 
         test_table.add_additional_resource("a plot",some_pdf, copy_file=True)
-        try:
-            test_table.copy_files(testdir)
-        except:
-            self.fail("Table.copy_files raised an unexpected exception.")
+        test_table.copy_files(testdir)
+

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -123,3 +123,11 @@ class TestTable(TestCase):
             with self.assertRaises(TypeError):
                 test_table.write_images(argument)
         self.doCleanups()
+
+    def test_add_additional_resource(self):
+        """Test the add_additional_resource function."""
+        test_table = Table("Some Table")
+        try:
+            test_table.add_additional_resource("some link","www.cern.ch")
+        except:
+            self.fail("Table.add_additional_resource raised an unexpected exception.")

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -124,7 +124,7 @@ class TestTable(TestCase):
                 test_table.write_images(argument)
         self.doCleanups()
 
-    def test_add_additional_resource(self):
+    def test_add_additional_resource(self): # pylint: disable=no-self-use
         """Test the add_additional_resource function."""
         test_table = Table("Some Table")
         test_table.add_additional_resource("some link","www.cern.ch")
@@ -139,4 +139,3 @@ class TestTable(TestCase):
 
         test_table.add_additional_resource("a plot",some_pdf, copy_file=True)
         test_table.copy_files(testdir)
-


### PR DESCRIPTION
Functionality related to additional resources has now been separated out into a mixin that is flexible inherited into both Table and Submission. When the Submission object creates the output files, it automatically calls the copy_files method of all tables.

Closes #157 