### PR TITLE
Fix missing file in tar ball

### DIFF
--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -226,16 +226,16 @@ class Variable(object):
                                                         self.uncertainties,
                                                         size=len(self._values)
                                                         )
-        for i in range(len(self._values)):
+        for i, value in enumerate(self._values):
             valuedict = defaultdict(list)
 
             if self.is_binned:
-                valuedict["low"] = helpers.relative_round(self._values[i][0],
+                valuedict["low"] = helpers.relative_round(value[0],
                                                           self.digits)
-                valuedict["high"] = helpers.relative_round(self._values[i][1],
+                valuedict["high"] = helpers.relative_round(value[1],
                                                            self.digits)
             else:
-                valuedict["value"] = helpers.relative_round(self._values[i],
+                valuedict["value"] = helpers.relative_round(value,
                                                             self.digits)
             # An uncertainty entry is only appended
             # if at least one of the uncertainties is not zero.

--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -516,7 +516,14 @@ class Submission(AdditionalResourceMixin):
 
         self.comment = raw
 
-
+    def files_to_copy_nested(self):
+        """
+        List files-to-copy for this Submission and nested daughters
+        """
+        files = self.files_to_copy
+        for table in self.tables:
+            files = files + table.files_to_copy
+        return files
 
     def create_files(self, outdir="."):
         """
@@ -554,13 +561,18 @@ class Submission(AdditionalResourceMixin):
         self.copy_files(outdir)
 
         # Put everything into a tarfile
+        files_to_add = []
+        files_to_add.extend(helpers.find_all_matching(outdir, "*.yaml"))
+        files_to_add.extend(helpers.find_all_matching(outdir, "*.png"))
+        files_to_add.extend(
+            [os.path.join(outdir, os.path.basename(x)) for x in  self.files_to_copy_nested()]
+        )
         with tarfile.open("submission.tar.gz", "w:gz") as tar:
-            for yaml_file in helpers.find_all_matching(outdir, "*.yaml"):
-                tar.add(yaml_file)
-            for png_file in helpers.find_all_matching(outdir, "*.png"):
-                tar.add(png_file)
-            for additional in self.files_to_copy:
-                tar.add(os.path.join(outdir, os.path.basename(additional)))
+            for filepath in files_to_add:
+                tar.add(
+                        filepath,
+                        arcname=os.path.basename(filepath)
+                        )
 
 
 class Uncertainty(object):
@@ -605,7 +617,7 @@ class Uncertainty(object):
 
     def set_values_from_intervals(self, intervals, nominal):
         """
-        Set values relative to set of nominal valuesself.
+        Set values relative to set of nominal values.
         Useful if you do not have the actual uncertainty available,
         but the upper and lower boundaries of an interval.
 

--- a/hepdata_lib/helpers.py
+++ b/hepdata_lib/helpers.py
@@ -79,12 +79,12 @@ def relative_round(value, relative_digits):
     """Rounds to a given relative precision"""
 
     if isinstance(value, tuple):
-        return (relative_round(x, relative_digits) for x in value)
+        return tuple((relative_round(x, relative_digits) for x in value))
 
     if value == 0 or isinstance(value, str) or np.isnan(value) or np.isinf(value):
         return value
 
-    value_precision = get_number_precision(value)
+    value_precision = get_number_precision(value) # pylint: disable invalid-unary-operand-type
     absolute_digits = -value_precision + relative_digits
 
     return round(value, int(absolute_digits))

--- a/hepdata_lib/helpers.py
+++ b/hepdata_lib/helpers.py
@@ -64,7 +64,7 @@ def get_number_precision(value):
     """
 
     if isinstance(value, tuple):
-        return (get_number_precision(x) for x in value)
+        return tuple((get_number_precision(x) for x in value))
 
     # if value is tuple, value == 0 might cause ValueError saying that
     # 'The truth value of an array with more than one element is ambiguous'

--- a/hepdata_lib/helpers.py
+++ b/hepdata_lib/helpers.py
@@ -84,8 +84,8 @@ def relative_round(value, relative_digits):
     if value == 0 or isinstance(value, str) or np.isnan(value) or np.isinf(value):
         return value
 
-    value_precision = get_number_precision(value) # pylint: disable invalid-unary-operand-type
-    absolute_digits = -value_precision + relative_digits
+    value_precision = get_number_precision(value)
+    absolute_digits = -value_precision + relative_digits  # pylint: disable=invalid-unary-operand-type
 
     return round(value, int(absolute_digits))
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     print("ROOT is required by this library.")
 
-DEPS = ['numpy', 'PyYAML>4.*', 'future', 'pylint']
+DEPS = ['numpy', 'PyYAML>4.*', 'future', 'pylint==2.9.6']
 
 HERE = path.abspath(path.dirname(__file__))
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -63,9 +63,9 @@ class TestHelpers(TestCase):
             (12.5, 1.25) : (2, 1),
             (0.125, 0.0125) : (0, -1)
         }
-        for key in ntuples:
-            prec1, prec2 = get_number_precision(key)
-            self.assertTrue((prec1, prec2) == ntuples[key])
+        for original_values, target_precisions in ntuples.items():
+            precisions = get_number_precision(original_values)
+            self.assertTrue(precisions == target_precisions)
 
 
     def test_get_value_precision_wrt_reference(self):

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -6,8 +6,8 @@ import shutil
 import string
 from builtins import bytes
 from unittest import TestCase
-from hepdata_lib import Submission, Table, Variable, Uncertainty
 import tarfile
+from hepdata_lib import Submission, Table, Variable, Uncertainty
 
 class TestSubmission(TestCase):
     """Test the Submission class."""
@@ -98,7 +98,7 @@ class TestSubmission(TestCase):
         self.doCleanups()
 
     def test_nested_files_to_copy(self):
-
+        """Test that file copying works when tables have files."""
         # Create random test file
         testfile = "testfile.txt"
         with open(testfile, "w") as f:
@@ -120,8 +120,8 @@ class TestSubmission(TestCase):
         sub.create_files(testdirectory)
 
         # Check that test file is actually in the tar ball
-        with tarfile.open("submission.tar.gz", "r:gz") as tf:
+        with tarfile.open("submission.tar.gz", "r:gz") as tar:
             try:
-                tf.getmember(testfile)
+                tar.getmember(testfile)
             except KeyError:
                 self.fail("Submission.create_files failed to write all files to tar ball.")


### PR DESCRIPTION
Fixes #173 

Summary of changes:
* Slight rework of how Submission handles file copying and tar ball creation. Now correctly propagates files from its Table daughters. Added explicit test for this case.
* Small changes forced by new pylint version. Have fixed pylint version now so that it does not keep changing randomly.
* While cleaning up pylint, encountered and fixed small bug in helpers where two functions returned generator objects rather than tuples.