### PR TITLE
Handle nested TPads to get TObject

### DIFF
--- a/hepdata_lib/root_utils.py
+++ b/hepdata_lib/root_utils.py
@@ -90,10 +90,27 @@ class RootFileReader(object):
             assert False
 
         except AssertionError as err:
-            msg="Cannot find any object in file {0} with path {1}".format(
+            msg="Cannot find any object in file {0} with path {1}.  Will try nested TPads".format(
                     self.tfile, path_to_object)
+            print(msg)
+        # If the above didn't work, try nested tpads
+        try:
+            obj = self.tfile.Get(parts[0])
+            for part in parts[1:]:
+                obj = obj.GetPrimitive(part)
+            
+            assert obj
+
+            return obj
+        except AssertionError as err:
+            msg="Cannot find any nested TPads in file {0} with path {1}".format(
+                    self.tfile, path_to_object)
+
             raise_from(IOError(msg), err)
+
         return None
+
+
 
     def read_graph(self, path_to_graph):
         """Extract lists of X and Y values from a TGraph.

--- a/hepdata_lib/root_utils.py
+++ b/hepdata_lib/root_utils.py
@@ -52,12 +52,15 @@ class RootFileReader(object):
         """
         Generalized function to retrieve a TObject from a file.
 
-        There are two use cases:
+        There are three use cases:
         1)  The object is saved under the exact path given.
         In this case, the function behaves identically to TFile.Get.
         2)  The object is saved as a primitive in a TCanvas.
         In this case, the path has to be formatted as
         PATH_TO_CANVAS/NAME_OF_PRIMITIVE
+        3)  The object is saved as a primitive in a TPad that is nested
+        in a TCanvas.  In this case, the path has to be formatted as
+        CANVAS/PAD1/PAD2.../NAME_OF_PRIMITIVE
 
 
         :param path_to_object: Absolute path in current TFile.

--- a/hepdata_lib/root_utils.py
+++ b/hepdata_lib/root_utils.py
@@ -108,6 +108,12 @@ class RootFileReader(object):
 
             raise_from(IOError(msg), err)
 
+        except AttributeError as err:
+            msg="Cannot find any nested TPads in file {0} with path {1}".format(
+                    self.tfile, path_to_object)
+
+            raise_from(IOError(msg), err)
+
         return None
 
 


### PR DESCRIPTION
I've added another attempt at retrieving the TObject from nested TPads if the path fails.  This is useful in the case of a TCanvas with TPads for ratio panels etc.