### PR TITLE
Validation of output tarballs 

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,3 @@ m2r
 sphinx_rtd_theme
 docutils<0.18
 mistune<2.0.0
-hepdata-validator>=0.3.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 m2r
 sphinx_rtd_theme
 docutils<0.18
+hepdata-validator>=0.3.2

--- a/examples/Getting_started.ipynb
+++ b/examples/Getting_started.ipynb
@@ -310,7 +310,7 @@
    "outputs": [],
    "source": [
     "outdir = \"example_output\"\n",
-    "submission.create_files(outdir)"
+    "submission.create_files(outdir,remove_old=True)"
    ]
   },
   {

--- a/examples/combine_limits.ipynb
+++ b/examples/combine_limits.ipynb
@@ -276,7 +276,7 @@
     "table.add_variable(obs)\n",
     "table.add_variable(exp)\n",
     "submission.add_table(table)\n",
-    "submission.create_files(\"example_output\")"
+    "submission.create_files(\"example_output\",remove_old=True)"
    ]
   },
   {

--- a/examples/correlation.ipynb
+++ b/examples/correlation.ipynb
@@ -282,7 +282,7 @@
     "# Create the submission object and write output\n",
     "sub = Submission()\n",
     "sub.add_table(table)\n",
-    "sub.create_files(\"./output/\")\n",
+    "sub.create_files(\"./output/\",remove_old=True)\n",
     "\n",
     "!ls -l submission.tar.gz"
    ]

--- a/examples/read_c_file.ipynb
+++ b/examples/read_c_file.ipynb
@@ -152,7 +152,7 @@
     "table.add_variable(obs)\n",
     "table.add_variable(exp)\n",
     "submission.add_table(table)\n",
-    "submission.create_files(\"example_output\")"
+    "submission.create_files(\"example_output\",remove_old=True)"
    ]
   },
   {

--- a/examples/reading_histograms.ipynb
+++ b/examples/reading_histograms.ipynb
@@ -258,7 +258,7 @@
     "\n",
     "submission.add_table(table)\n",
     "\n",
-    "submission.create_files(\"example_output\")"
+    "submission.create_files(\"example_output\",remove_old=True)"
    ]
   },
   {
@@ -311,7 +311,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -525,7 +525,7 @@ class Submission(AdditionalResourceMixin):
             files = files + table.files_to_copy
         return files
 
-    def create_files(self, outdir=".", validate=True):
+    def create_files(self, outdir=".", validate=True, remove_old=True):
         """
         Create the output files.
 
@@ -534,7 +534,12 @@ class Submission(AdditionalResourceMixin):
 
         If `validate` is True, the hepdata-validator package will be used to validate the
         output tar ball.
+
+        If `remove_old` is True, the output directory will be deleted before recreation.
         """
+        if remove_old and os.path.exists(outdir):
+            shutil.rmtree(outdir)
+
         if not os.path.exists(outdir):
             os.makedirs(outdir)
 

--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -581,6 +581,9 @@ class Submission(AdditionalResourceMixin):
         if validate:
             full_submission_validator = FullSubmissionValidator()
             is_archive_valid = full_submission_validator.validate(archive=tarfile_path)
+            if not is_archive_valid:
+                for filename in full_submission_validator.get_messages():
+                    full_submission_validator.print_errors(filename)
             assert is_archive_valid, "The tar ball is not valid"
 
 class Uncertainty(object):

--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -11,7 +11,6 @@ from collections import defaultdict
 import numpy as np
 import yaml
 from future.utils import raise_from
-
 # try to use LibYAML bindings if possible
 try:
     from yaml import CLoader as Loader, CSafeDumper as Dumper
@@ -19,6 +18,7 @@ except ImportError:
     from yaml import Loader, SafeDumper as Dumper
 from yaml.representer import SafeRepresenter
 
+from hepdata_validator.full_submission_validator import FullSubmissionValidator
 from hepdata_lib import helpers
 from hepdata_lib.root_utils import RootFileReader
 
@@ -579,7 +579,6 @@ class Submission(AdditionalResourceMixin):
                         )
 
         if validate:
-            from hepdata_validator.full_submission_validator import FullSubmissionValidator
             full_submission_validator = FullSubmissionValidator()
             is_archive_valid = full_submission_validator.validate(archive=tarfile_path)
             assert is_archive_valid, "The tar ball is not valid"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+PyYAML>4.*
+future
+six
+hepdata-validator>=0.3.2

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,6 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
@@ -40,7 +38,6 @@ setup(
     install_requires=DEPS,
     setup_requires=['pytest-runner', 'pytest-cov'],
     tests_require=['pytest', 'papermill', 'six',
-                   'pylint==1.9.5; python_version<"3"',
                    'pylint==2.9.6; python_version>="3"',
                   ],
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     print("ROOT is required by this library.")
 
-DEPS = ['numpy', 'PyYAML>4.*', 'future', 'six']
+DEPS = ['numpy', 'PyYAML>4.*', 'future', 'six','hepdata-validator>=0.3.2']
 
 HERE = path.abspath(path.dirname(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ try:
 except ImportError:
     print("ROOT is required by this library.")
 
-DEPS = ['numpy', 'PyYAML>4.*', 'future', 'six','hepdata-validator>=0.3.2']
+with open("requirements.txt","r") as f:
+    DEPS = f.readlines()
 
 HERE = path.abspath(path.dirname(__file__))
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -2,18 +2,20 @@
 # -*- coding:utf-8 -*-
 """Test Output."""
 from __future__ import print_function
-import os
 from collections import defaultdict
 from unittest import TestCase
 import shutil
 import yaml
+import os
 from hepdata_lib import Submission, Table, Variable
+from test_utilities import tmp_directory_name
 
 class TestOutput(TestCase):
     """Test output"""
 
     def test_yaml_output(self):
         """Test yaml dump"""
+        tmp_dir = tmp_directory_name()
 
         # Create test dictionary
         testlist = [("x", 1.2), ("x", 2.2), ("y", 0.12), ("y", 0.22)]
@@ -23,7 +25,6 @@ class TestOutput(TestCase):
 
         # Create test submission
         test_submission = Submission()
-        testdir = "./output"
         test_table = Table("TestTable")
         x_variable = Variable("X", is_independent=True, is_binned=False)
         x_variable.values = testdict['x']
@@ -32,11 +33,12 @@ class TestOutput(TestCase):
         test_table.add_variable(x_variable)
         test_table.add_variable(y_variable)
         test_submission.add_table(test_table)
-        test_submission.create_files(testdir)
+        test_submission.create_files(tmp_dir)
 
         # Test read yaml file
+        table_file = os.path.join(tmp_dir, "testtable.yaml")
         try:
-            with open("output/testtable.yaml", 'r') as testfile:
+            with open(table_file, 'r') as testfile:
                 testyaml = yaml.safe_load(testfile)
         except yaml.YAMLError as exc:
             print(exc)
@@ -45,10 +47,10 @@ class TestOutput(TestCase):
         testtxt = ("dependent_variables:\n- header:\n    name: Y\n  values:\n" +
                    "  - value: 0.12\n  - value: 0.22\nindependent_variables:\n" +
                    "- header:\n    name: X\n  values:\n  - value: 1.2\n  - value: 2.2\n")
-        with open("output/testtable.yaml", 'r') as testfile:
+        with open(table_file, 'r') as testfile:
             testyaml = testfile.read()
 
         self.assertEqual(str(testyaml), testtxt)
         self.addCleanup(os.remove, "submission.tar.gz")
-        self.addCleanup(shutil.rmtree, testdir)
+        self.addCleanup(shutil.rmtree, tmp_dir)
         self.doCleanups()

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -5,10 +5,10 @@ from __future__ import print_function
 from collections import defaultdict
 from unittest import TestCase
 import shutil
-import yaml
 import os
-from hepdata_lib import Submission, Table, Variable
+import yaml
 from test_utilities import tmp_directory_name
+from hepdata_lib import Submission, Table, Variable
 
 class TestOutput(TestCase):
     """Test output"""

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -73,9 +73,8 @@ class TestSubmission(TestCase):
 
         testdir = "test_output"
         test_submission = Submission()
-        self.addCleanup(os.remove, "submission.tar.gz")
-        self.addCleanup(shutil.rmtree, testdir)
-
+        tab = Table("test")
+        test_submission.add_table(tab)
         test_submission.create_files(testdir)
 
         self.doCleanups()

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -7,6 +7,7 @@ import string
 from builtins import bytes
 from unittest import TestCase
 import tarfile
+from test_utilities import tmp_directory_name
 from hepdata_lib import Submission, Table, Variable, Uncertainty
 
 class TestSubmission(TestCase):

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -71,7 +71,7 @@ class TestSubmission(TestCase):
     def test_create_files(self):
         """Test create_files() for Submission."""
 
-        testdir = "test_output"
+        testdir = tmp_directory_name()
         test_submission = Submission()
         tab = Table("test")
         test_submission.add_table(tab)

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -80,6 +80,37 @@ class TestSubmission(TestCase):
 
         self.doCleanups()
 
+    def test_create_files_with_removal(self):
+        """Test the removal of old files in create_files()"""
+        testdir = tmp_directory_name()
+
+        # Step 1: Create test directory containing random file
+        os.makedirs(testdir)
+        self.addCleanup(shutil.rmtree, testdir)
+        testfile = os.path.join(testdir, "test.txt")
+        with open(testfile, "w") as f:
+            f.write("test")
+        self.assertTrue(os.path.isfile(testfile))
+
+        # Step 2: Create submission and write output to test directory
+        # Without overwriting of files
+        test_submission = Submission()
+        tab = Table("test")
+        test_submission.add_table(tab)
+        test_submission.create_files(testdir, remove_old=False)
+
+        # Test file should still exist
+        self.assertTrue(os.path.isfile(testfile))
+
+        # Step 3: Recreate submission files with removal
+        test_submission.create_files(testdir, remove_old=True)
+
+        # Test file should no longer exist
+        self.assertFalse(os.path.isfile(testfile))
+
+
+
+
     def test_read_abstract(self):
         """Test read_abstract function."""
         some_string = string.ascii_lowercase
@@ -125,3 +156,4 @@ class TestSubmission(TestCase):
                 tar.getmember(testfile)
             except KeyError:
                 self.fail("Submission.create_files failed to write all files to tar ball.")
+

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -156,4 +156,3 @@ class TestSubmission(TestCase):
                 tar.getmember(testfile)
             except KeyError:
                 self.fail("Submission.create_files failed to write all files to tar ball.")
-

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -5,8 +5,8 @@ import os
 import shutil
 from unittest import TestCase
 
-from hepdata_lib import Table, Variable, Uncertainty
 from test_utilities import tmp_directory_name
+from hepdata_lib import Table, Variable, Uncertainty
 
 class TestTable(TestCase):
     """Test the Table class."""

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -6,6 +6,7 @@ import shutil
 from unittest import TestCase
 
 from hepdata_lib import Table, Variable, Uncertainty
+from test_utilities import tmp_directory_name
 
 class TestTable(TestCase):
     """Test the Table class."""
@@ -61,7 +62,7 @@ class TestTable(TestCase):
         test_table = Table("Some Table")
         test_variable = Variable("Some Variable")
         test_table.add_variable(test_variable)
-        testdir = "test_output"
+        testdir = tmp_directory_name()
         self.addCleanup(shutil.rmtree, testdir)
         try:
             test_table.write_yaml(testdir)
@@ -110,7 +111,7 @@ class TestTable(TestCase):
 
         # This should work fine
         test_table.add_image(some_pdf)
-        testdir = "test_output"
+        testdir = tmp_directory_name()
         self.addCleanup(shutil.rmtree, testdir)
         try:
             test_table.write_images(testdir)
@@ -133,7 +134,7 @@ class TestTable(TestCase):
         """Test the copy_files function."""
         test_table = Table("Some Table")
         some_pdf = "%s/minimal.pdf" % os.path.dirname(__file__)
-        testdir = "test_output"
+        testdir = tmp_directory_name()
         self.addCleanup(shutil.rmtree, testdir)
         os.makedirs(testdir)
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -62,6 +62,17 @@ def get_random_id(length=12):
     return "".join(random.sample(string.ascii_uppercase+string.digits, length))
 
 
+def tmp_directory_name():
+    """
+    Generate a random directory name for testing.
+
+    Guaranteed to not exist.
+    """
+    tmp_name = "/tmp/hepdata_lib_test_" + get_random_id()
+    if os.path.exists(tmp_name):
+        return tmp_directory_name()
+    return tmp_name
+
 def remove_if_exist(path_to_file):
     """Remove file if it exists."""
     if os.path.exists(path_to_file):


### PR DESCRIPTION
With this PR, `Submission.create_files` now automatically calls the hepdata validator on the output file. An AssertionError is thrown if the tar ball is found to be invalid.


Closes #160