### PR TITLE
Fix building docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
 m2r
 sphinx_rtd_theme
 docutils<0.18
+mistune<2.0.0
+


### PR DESCRIPTION
Building the docs is [failing](https://readthedocs.org/projects/hepdata-lib/builds/15522884/) again due to some major version change of sphinx dependencies. Pinning `mistune` version to < 2 should fix this, see e.g. https://github.com/Azure/azure-sdk-for-python/issues/22019#issuecomment-987195928.