### PR TITLE
ci: Update tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
         source root/bin/thisroot.sh
         python -m pytest tests
 
-    - name: Report contrib coverage with Codecov
+    - name: Report coverage with Codecov
       uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,71 +1,105 @@
 
 name: tests
 #Running tests on all branches
-on: [push,pull_request]
+on:
+  push:
+  pull_request:
+    branches:
+    - master
+  workflow_dispatch:
 
 jobs:
   # This is a job for linux python3 tests
   linuxpy3:
-      runs-on: [ubuntu-20.04]
-      steps:
-        - uses: actions/checkout@v2
 
-        # Install dependencies
-        - name: Install python dependencies
-          run: |
-            curl https://bootstrap.pypa.io/get-pip.py > get-pip.py
-            python3 get-pip.py
-            python3 -m pip install pylint==2.9.6 pytest_pylint configparser astroid pyyml papermill nbconvert jupyter pytest pytest-cov
-        - name: Fixup ImageMagick
-          run: |
-            sudo sed -i '/.*PDF.*/ s/none/read | write/g' /etc/ImageMagick*/policy.xml
-            ls /etc/ImageMagick*/policy.xml
-            cat /etc/ImageMagick*/policy.xml
-            sudo apt update
-            sudo apt install ghostscript
-            echo "---GS---"
-            which gs
-            echo "--------"
-        - name: Install ROOT
-          run: |
-            wget -q https://root.cern/download/root_v6.24.00.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
-            tar xf *tar.gz
-            source root/bin/thisroot.sh
-        # Run pytest
-        - name: Run pytest
-          run: |
-            source root/bin/thisroot.sh
-            python3 -m pip install -e .
-            python3 setup.py test
-            
-        # Save notebooks
-        - name: Save notebooks
-          if: ${{ always() }}
-          run: |
-            python3 -m jupyter kernelspec list
-            python3 -m jupyter nbconvert --ExecutePreprocessor.timeout=600 --ExecutePreprocessor.allow_errors=True --to html --execute examples/*.ipynb
-            
-        # Upload notebooks
-        - name: Upload notebooks
-          if: ${{ always() }}
-          uses: actions/upload-artifact@v2
-          with:
-            name: notebooks py3
-            path: examples/*.html
+    # Setup the Python that the ROOT binary was built against
+    runs-on: ${{ matrix.os }}
+    # On push events run the CI only on master by default, but run on any branch if the commit message contains '[ci all]'
+    if: >-
+      github.event_name != 'push'
+      || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+      || (github.event_name == 'push' && github.ref != 'refs/heads/master' && contains(github.event.head_commit.message, '[ci all]'))
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.8"]
 
-        # Run pylint
-        - name: Run pylint
-          if: ${{ always() }}
-          run: |
-            python3 -m pip install -e .
-            python3 -m pylint hepdata_lib/*.py
-            python3 -m pylint tests/*.py --rcfile=tests/pylintrc
-        - name: Upload coverage data to coveralls.io
-          run: |
-            python -m pip install coveralls==2.2
-            coveralls --service=github
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    # Install dependencies
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade \
+          'pylint==2.9.6' \
+          pytest_pylint \
+          configparser \
+          astroid \
+          pyyml \
+          papermill \
+          nbconvert \
+          jupyter \
+          pytest \
+          pytest-cov
+
+    - name: Install hepdata_lib
+      run: python -m pip install .[test]
+
+    - name: Fixup ImageMagick
+      run: |
+        sudo sed -i '/.*PDF.*/ s/none/read | write/g' /etc/ImageMagick*/policy.xml
+        ls /etc/ImageMagick*/policy.xml
+        cat /etc/ImageMagick*/policy.xml
+        sudo apt update
+        sudo apt install ghostscript
+        echo "---GS---"
+        which gs
+        echo "--------"
+
+    - name: Install ROOT
+      run: |
+        wget -q https://root.cern/download/root_v6.24.00.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
+        tar xf *tar.gz
+        source root/bin/thisroot.sh
+        root-config --python-version
+
+    # Use python -m pytest to add current working dir as src/ dir layout not used
+    - name: Run pytest
+      run: |
+        source root/bin/thisroot.sh
+        python -m pytest tests
+
+    - name: Report contrib coverage with Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./coverage.xml
+        flags: unittests-${{ matrix.python-version }}
+
+    - name: Save notebooks
+      if: ${{ always() }}
+      run: |
+        python -m jupyter kernelspec list
+        python -m jupyter nbconvert --ExecutePreprocessor.timeout=600 --ExecutePreprocessor.allow_errors=True --to html --execute examples/*.ipynb
+
+    - name: Upload notebooks
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: notebooks py3
+        path: examples/*.html
+
+    - name: Run pylint
+      if: ${{ always() }}
+      run: |
+        python -m pylint hepdata_lib/*.py
+        python -m pylint tests/*.py --rcfile=tests/pylintrc
+
  # This is a job for macOS python3 tests
 #   macospy3:
 #     runs-on: macos-latest

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![DOI](https://zenodo.org/badge/129248575.svg)](https://zenodo.org/badge/latestdoi/129248575)
 [![PyPI version](https://badge.fury.io/py/hepdata-lib.svg)](https://badge.fury.io/py/hepdata-lib)
 [![Actions Status](https://github.com/HEPData/hepdata_lib/workflows/tests/badge.svg)](https://github.com/HEPData/hepdata_lib/actions)
-[![Coverage Status](https://coveralls.io/repos/github/HEPData/hepdata_lib/badge.svg?branch=master)](https://coveralls.io/github/HEPData/hepdata_lib?branch=master)
+[![Coverage Status](https://codecov.io/gh/HEPData/hepdata_lib/graph/badge.svg?branch=master)](https://codecov.io/gh/HEPData/hepdata_lib?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/hepdata-lib/badge/)](http://hepdata-lib.readthedocs.io/)
 [![Docker image](https://github.com/HEPData/hepdata_lib/actions/workflows/docker.yml/badge.svg)](https://github.com/HEPData/hepdata_lib/pkgs/container/hepdata_lib)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.2%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.pytest.ini_options]
+minversion = "6.0"
+xfail_strict = true
+addopts = [
+    "-ra",
+    "--cov=hepdata_lib",
+    "--cov-branch",
+    "--showlocals",
+    "--strict-markers",
+    "--strict-config",
+    "--cov-report=term-missing",
+    "--cov-report=xml",
+    "--cov-report=html",
+]
+log_cli_level = "info"
+testpaths = "tests"

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,3 @@ universal=1
 
 [aliases]
 test=pytest
-
-[tool:pytest]
-addopts = --cov=hepdata_lib
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,3 @@
 # need to generate separate wheels for each Python version that you
 # support.
 universal=1
-
-[aliases]
-test=pytest


### PR DESCRIPTION
* Add workflow dispatch option to run on demand.
* Test against Python 3.8 which is the version of Python the ROOT binary was compiled against given the output of `root-config --python-version`.
* Update all GitHub Actions.
* Avoid deprecated direct calls to `python setup.py` and use local pip installs.
* Use `python -m pytest` to add current working directory to `sys.path` as `src/` dir layout not used.
   - c.f. https://docs.pytest.org/en/7.1.x/explanation/pythonpath.html
* Run on push events only if to master to let coverage from PRs report properly.
* Use Codecov for reporting coverage.
   - Update badge in README to use Codecov [![Coverage Status](https://codecov.io/gh/HEPData/hepdata_lib/graph/badge.svg?branch=master)](https://codecov.io/gh/HEPData/hepdata_lib?branch=master)