### PR TITLE
Add dependabot config for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Following instructions at https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates

Later PRs could do the same for Python/pip and maybe also Docker.