### PR TITLE
Replace m2r by m2r2 and fix version to 0.3.3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ release = '0.10.1'
 # ones.
 extensions = [
     'sphinx.ext.githubpages',
-    'm2r',
+    'm2r2',
     'sphinx.ext.autodoc'
 ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-m2r
+m2r2==0.3.3
 sphinx_rtd_theme
 docutils<0.18
 mistune<2.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 m2r2==0.3.3
 sphinx_rtd_theme
-docutils<0.18
+docutils==0.19
 mistune<2.0.0


### PR DESCRIPTION
Unfortunately, this doesn't seem to make the module index work again (see #138), but at least the docs compile again and we're not using outdated/unmaintained packages anymore.
Also, docs review introduced in #202 works nicely (once the docs build and don't fail).

<!-- readthedocs-preview hepdata-lib start -->
----
:books: Documentation preview :books:: https://hepdata-lib--207.org.readthedocs.build/en/207/

<!-- readthedocs-preview hepdata-lib end -->