### PR TITLE
Add sphinx autosummary extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,8 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../../hepdata_lib'))
+sys.path.insert(0, os.path.abspath('../..'))
+sys.path.insert(0, os.path.abspath('../'))
 
 if (sys.version_info > (3, 3)):
     # Python 3.3
@@ -62,7 +64,8 @@ release = '0.10.1'
 extensions = [
     'sphinx.ext.githubpages',
     'm2r2',
-    'sphinx.ext.autodoc'
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,7 +1,7 @@
 Code Documentation
 ====================
 
-.. toctree::
-   :maxdepth: 4
+.. autosummary::
+   :toctree: generated
 
    hepdata_lib


### PR DESCRIPTION
Fixes https://github.com/HEPData/hepdata_lib/issues/138 and supersedes https://github.com/HEPData/hepdata_lib/pull/152 (at least that's what I'm trying based on https://www.sphinx-doc.org/en/master/tutorial/automatic-doc-generation.html) - 2nd attempt

<!-- readthedocs-preview hepdata-lib start -->
----
:books: Documentation preview :books:: https://hepdata-lib--210.org.readthedocs.build/en/210/

<!-- readthedocs-preview hepdata-lib end -->