### PR TITLE
Dealing with symmetric and asymmetric uncertainties at the same time

### DIFF
--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -8,6 +8,7 @@ import shutil
 import tarfile
 import warnings
 from collections import defaultdict
+from decimal import Decimal
 import numpy as np
 import yaml
 from future.utils import raise_from
@@ -249,15 +250,24 @@ class Variable(object):
                                 unc.label
                         })
                     else:
-                        valuedict['errors'].append({
-                            "asymerror": {
-                                "minus":
-                                    helpers.relative_round(unc.values[i][0], self.digits),
-                                "plus":
-                                    helpers.relative_round(unc.values[i][1], self.digits)
-                            },
-                            "label": unc.label
-                        })
+                        sum_unc = Decimal(float(unc.values[i][0]) + float(unc.values[i][1]))
+                        if sum_unc.is_zero():
+                            valuedict['errors'].append({
+                                "symerror":
+                                    helpers.relative_round(unc.values[i][1], self.digits),
+                                "label":
+                                    unc.label
+                            })
+                        else:
+                            valuedict['errors'].append({
+                                "asymerror": {
+                                    "minus":
+                                        helpers.relative_round(unc.values[i][0], self.digits),
+                                    "plus":
+                                        helpers.relative_round(unc.values[i][1], self.digits)
+                                },
+                                "label": unc.label
+                            })
             elif self.uncertainties:
                 print(
                     "Warning: omitting 'errors' since all uncertainties " \

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -91,4 +91,4 @@ class TestUncertainty(TestCase):
         # Verify the pattern: the correct one VS output of the make_dict() function
         pattern = ['symerror', 'asymerror', 'asymerror', 'symerror']
         self.assertTrue((list(dictionary['values'][i]['errors'][0].keys())[
-                        0], pattern[i]) for i in len(pattern))
+                        0], value) for i, value in enumerate(pattern))

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -69,3 +69,23 @@ class TestUncertainty(TestCase):
         # Check that both agree
         self.assertTrue(all((test_utilities.tuple_compare(tup1, tup2) \
                         for tup1, tup2 in zip(testunc.values, refunc.values))))
+
+    def test_mixed_uncertainties(self):
+        '''Test behavior in case of symmetric and asymmetric uncertainties'''
+
+        # Create a Variable with random values
+        var = Variable("testvar")
+        var.is_binned = False
+        var.values = [1, 2, 3, 4]
+        var.make_dict()
+
+        # Add mixed uncertainties, declaring asymmetric type in order to allow up/down variations
+        unc = Uncertainty("fake_unc")
+        unc.is_symmetric = False
+        unc.values = [(-1, 1), (-1.5, 2), (-3, 2), (-2.5, 2.5)]
+        var.add_uncertainty(unc)
+        dictionary = var.make_dict()
+
+        # Verify the pattern: the correct one VS output of the make_dict() function
+        pattern = ['symerror', 'asymerror', 'asymerror', 'symerror']
+        self.assertTrue((list(dictionary['values'][i]['errors'][0].keys())[0], pattern[i]) for i in range(4))

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -9,6 +9,7 @@ from hepdata_lib import Variable, Uncertainty
 
 class TestUncertainty(TestCase):
     """Test the Uncertainty class."""
+
     def test_scale_values(self):
         '''Test behavior of Uncertainty.scale_values function'''
         values = list(range(0, 300, 1))
@@ -50,7 +51,8 @@ class TestUncertainty(TestCase):
         # Dummy central values and variatons relative to central value
         npoints = 100
         values = list(range(0, npoints, 1))
-        uncertainty = [(-random.uniform(0, 1), random.uniform(0, 1)) for _ in range(100)]
+        uncertainty = [(-random.uniform(0, 1), random.uniform(0, 1))
+                       for _ in range(npoints)]
 
         # Convert +- error to interval bounds
         intervals = [(val + unc_minus, val + unc_plus)
@@ -67,7 +69,7 @@ class TestUncertainty(TestCase):
         testunc.set_values_from_intervals(intervals, nominal=values)
 
         # Check that both agree
-        self.assertTrue(all((test_utilities.tuple_compare(tup1, tup2) \
+        self.assertTrue(all((test_utilities.tuple_compare(tup1, tup2)
                         for tup1, tup2 in zip(testunc.values, refunc.values))))
 
     def test_mixed_uncertainties(self):
@@ -88,4 +90,5 @@ class TestUncertainty(TestCase):
 
         # Verify the pattern: the correct one VS output of the make_dict() function
         pattern = ['symerror', 'asymerror', 'asymerror', 'symerror']
-        self.assertTrue((list(dictionary['values'][i]['errors'][0].keys())[0], pattern[i]) for i in range(4))
+        self.assertTrue((list(dictionary['values'][i]['errors'][0].keys())[
+                        0], pattern[i]) for i in len(pattern))


### PR DESCRIPTION
Hi! This MR adds more flexibility when dealing with distributions/plots having low non-zero yields: in these cases, due to the limited statistics, it may happen that the uncertainty is symmetric, but the relative value being larger with respect to the nominal value. Therefore, it's a common practice to cap the negative variation at the nominal value to avoid a negative yield, being unphysical.

From a technical point of view, uncertainties are given as asymmetric, but when the up/down variations have opposite sign only, thus sharing the same magnitude, they are considered as symmetric. On the other hand, nothing changes for asymmetric ones. So, the resulting _yaml_ file will have symmetric or asymmetric uncertainties accordingly, improving general readability in case of mixed entries. 

Finally, as uncertainties are floating-point numbers, the [decimal](https://docs.python.org/3/library/decimal.html) library is used to perform the mathematical comparison and calculation(s).

Hope it is fine but, please, let me know if you have comments and/or questions. 
Thanks in advance,
Francesco

<!-- readthedocs-preview hepdata-lib start -->
----
:books: Documentation preview :books:: https://hepdata-lib--213.org.readthedocs.build/en/213/

<!-- readthedocs-preview hepdata-lib end -->