### PR TITLE
fix: Use valid project/version requirement specifiers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-PyYAML>4.*
+PyYAML>=4.0
 future
 six
 hepdata-validator>=0.3.2


### PR DESCRIPTION
'install_requires' must be a string or list of strings containing valid project/version requirement specifiers. Without this fix installation will fail with modern pip.