### PR TITLE
ci: Use micromamba to test Python and ROOT

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,9 +8,13 @@ on:
     - master
   workflow_dispatch:
 
+# Needed for micromamba pickup
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
-  # This is a job for linux python3 tests
-  linuxpy3:
+  test:
 
     # Setup the Python that the ROOT binary was built against
     runs-on: ${{ matrix.os }}
@@ -22,15 +26,40 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8"]
+        root-version: ["6.24", "6.26"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        exclude:
+          - root-version: "6.24"
+            python-version: "3.10"
+          - root-version: "6.26"
+            python-version: "3.6"
+          - root-version: "6.26"
+            python-version: "3.7"
+        include:
+          - os: macos-latest
+            root-version: "6.26"
+            python-version: "3.10"
 
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
+    - name: Setup Micromamba environment
+      uses: mamba-org/provision-with-micromamba@v15
       with:
-        python-version: ${{ matrix.python-version }}
+        environment-file: false
+        environment-name: ci
+        extra-specs: |
+          python=${{ matrix.python-version }}
+          root=${{ matrix.root-version }}
+          imagemagick
+          ghostscript
+          pip
+        channels: conda-forge
+
+    - name: ROOT info
+      run: |
+        root-config --version
+        root-config --python-version
 
     # Install dependencies
     - name: Install python dependencies
@@ -49,30 +78,11 @@ jobs:
           pytest-cov
 
     - name: Install hepdata_lib
-      run: python -m pip install .[test]
-
-    - name: Fixup ImageMagick
-      run: |
-        sudo sed -i '/.*PDF.*/ s/none/read | write/g' /etc/ImageMagick*/policy.xml
-        ls /etc/ImageMagick*/policy.xml
-        cat /etc/ImageMagick*/policy.xml
-        sudo apt update
-        sudo apt install ghostscript
-        echo "---GS---"
-        which gs
-        echo "--------"
-
-    - name: Install ROOT
-      run: |
-        wget -q https://root.cern/download/root_v6.24.00.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
-        tar xf *tar.gz
-        source root/bin/thisroot.sh
-        root-config --python-version
+      run: python -m pip install '.[test]'
 
     # Use python -m pytest to add current working dir as src/ dir layout not used
     - name: Run pytest
       run: |
-        source root/bin/thisroot.sh
         python -m pytest tests
 
     - name: Report coverage with Codecov
@@ -99,113 +109,3 @@ jobs:
       run: |
         python -m pylint hepdata_lib/*.py
         python -m pylint tests/*.py --rcfile=tests/pylintrc
-
- # This is a job for macOS python3 tests
-#   macospy3:
-#     runs-on: macos-latest
-#     steps:
-#       - uses: actions/checkout@v2
-        
-#       # Install dependencies
-#       - name: Install dependencies
-#         run: |
-#           brew update
-#           brew install fontconfig gd gettext libffi glib jasper netpbm gts graphviz gsl libxml2 openblas numpy tbb xrootd || true
-#           brew install python@3.8 openssl@1.1 || true
-          
-#       # Run pytest
-#       - name: Run pytest
-#         run: |
-#           ROOT_VERSION=6.20.04_1
-#           curl -O https://clange.web.cern.ch/clange/root-v${ROOT_VERSION}.tar.gz
-#           tar xzf root-v${ROOT_VERSION}.tar.gz
-#           mkdir -p /usr/local/Cellar/root
-#           mv ${ROOT_VERSION} /usr/local/Cellar/root/
-#           cd /usr/local/Cellar/root/${ROOT_VERSION}
-#           export PATH=${PWD}/bin:$(brew --cellar python@3.8)/$(ls $(brew --cellar python@3.8))/bin:${PATH}
-#           export PYTHONPATH=${PWD}/lib/root:${PYTHONPATH}
-#           export LD_LIBRARY_PATH=${PWD}/lib/root:${LD_LIBRARY_PATH}
-#           echo ${PYTHONPATH}
-#           cd -
-#           python3 -m pip install pytest ipykernel papermill jupyter_client nbconvert
-#           python3 setup.py test
-          
-#       # Save notebooks
-#       - name: Save notebooks
-#         if: ${{ always() }}
-#         run: |
-#           cd /usr/local/Cellar/root/${ROOT_VERSION}
-#           export PATH=${PWD}/bin:$(brew --cellar python@3.8)/$(ls $(brew --cellar python@3.8))/bin:${PATH}
-#           export PYTHONPATH=${PWD}/lib/root:${PYTHONPATH}
-#           export LD_LIBRARY_PATH=${PWD}/lib/root:${LD_LIBRARY_PATH}
-#           echo ${PYTHONPATH}
-#           cd -
-#           python3 -m jupyter nbconvert --ExecutePreprocessor.timeout=600 --ExecutePreprocessor.kernel_name=python3 --ExecutePreprocessor.allow_errors=True --to html --execute examples/*.ipynb
-          
-#       # Upload notebooks
-#       - name: Upload notebooks
-#         if: ${{ always() }}
-#         uses: actions/upload-artifact@v2
-#         with:
-#           name: notebooks macOS
-#           path: examples/*.html
-          
-#       # Run Pylint
-#       - name: Run Pylint
-#         if: ${{ always() }}
-#         run: |
-#           python3 -m pip install pytest ipykernel papermill
-#           python3 -m pip install -e .
-#           python3 -m pylint hepdata_lib/*.py
-#           python3 -m pylint tests/*.py --rcfile=tests/pylintrc
-          
-#  # This is a job for linux python2.7 tests
-#   linuxpy27:
-#     runs-on: ubuntu-16.04
-#     steps:
-#     - uses: actions/checkout@v2
-      
-#     # Install dependencies
-#     - name: Install dependencies
-#       run: |
-#         sudo apt-get install python2.7
-#         python -m pip install --upgrade pip
-#         python -m pip install --upgrade setuptools
-#         curl -O https://root.cern.ch/download/root_v6.20.00.Linux-ubuntu16-x86_64-gcc5.4.tar.gz
-#         tar xzf root_v6.20.00.Linux-ubuntu16-x86_64-gcc5.4.tar.gz
-#         python -m pip install numpy==1.16.5
-#         sudo sed -i '/MVG/d' /etc/ImageMagick-6/policy.xml
-#         sudo sed -i '/PDF/{s/none/read|write/g}' /etc/ImageMagick-6/policy.xml
-#         sudo sed -i '/PDF/ a <policy domain="coder" rights="read|write" pattern="LABEL" />' /etc/ImageMagick-6/policy.xml
-#         python -m pip install --upgrade enum34 pytest_pylint configparser astroid future ipykernel papermill nbconvert
-#         sudo apt update
-#         sudo apt install -y ghostscript
-        
-#     # Run pytest
-#     - name: Run pytest
-#       run: |
-#         source root/bin/thisroot.sh
-#         python setup.py test
-        
-#     # Save notebooks
-#     - name: Save notebooks
-#       if: ${{ always() }}
-#       run: |
-#         source root/bin/thisroot.sh
-#         export PATH=$PATH:~/.local/bin
-#         source ~/.bash_profile
-#         jupyter nbconvert --ExecutePreprocessor.timeout=600 --ExecutePreprocessor.kernel_name=python2 --ExecutePreprocessor.allow_errors=True --to html --execute examples/*.ipynb
-#     # Upload notebooks
-#     - name: Upload notebooks
-#       if: ${{ always() }}
-#       uses: actions/upload-artifact@v2
-#       with:
-#         name: notebooks py27
-#         path: examples/*.html
-        
-#     # Run pylint
-#     - name: Run Pylint
-#       if: ${{ always() }}
-#       run: |      
-#         python -m pylint hepdata_lib/*.py
-#         python -m pylint tests/*.py --rcfile=tests/pylintrc


### PR DESCRIPTION
Resolves #200.

Requires #218 to go in first.

* Use the mamba-org/provision-with-micromamba GitHub action to setup a micromamba enviroment with a ROOT version and CPython version defined by the CI matrix.
   - Set a default shell of a Bash login to automatically source the micromamba environment.
* Test ROOT v6.24.x and v6.26.x and all compatible Python versions with them.
   - Exclude versions of Python that are not compatible with ROOT releases.
   - Test on macOS with the latest ROOT release on conda-forge (v6.26.x) and the latest supported CPython version (3.10).
* Install ImageMagick and Ghostscript through conda-forge.
* Remove commented out macOS and Python 2.7 workflows.

<!-- readthedocs-preview hepdata-lib start -->
----
:books: Documentation preview :books:: https://hepdata-lib--220.org.readthedocs.build/en/220/

<!-- readthedocs-preview hepdata-lib end -->