### PR TITLE
build: Add requires-python metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     keywords='HEPData physics OpenData',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     zip_safe=False,
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
     install_requires=DEPS,
     setup_requires=['pytest-runner', 'pytest-cov'],
     tests_require=['pytest', 'papermill', 'six',


### PR DESCRIPTION
Add requires-python metadata through the addition of setuptools's python_requires in setup.py.
   - c.f. https://peps.python.org/pep-0621/#requires-python

The lower bound versions are selected to support the versions of CPython currently supported: 2.7 and 3.6+. Currently these lower bound versions of CPython (2.7, 3.6) have all reached EOL:

```console
$ python -m pip install --upgrade norwegianblue
$ eol python
┌───────┬────────────┬─────────┬────────────────┬────────────┐
│ cycle │  release   │  latest │ latest release │    eol     │
├───────┼────────────┼─────────┼────────────────┼────────────┤
│  3.11 │ 2022-10-24 │  3.11.2 │   2023-02-07   │ 2027-10-24 │
│  3.10 │ 2021-10-04 │ 3.10.10 │   2023-02-07   │ 2026-10-04 │
│  3.9  │ 2020-10-05 │  3.9.16 │   2022-12-06   │ 2025-10-05 │
│  3.8  │ 2019-10-14 │  3.8.16 │   2022-12-06   │ 2024-10-14 │
│  3.7  │ 2018-06-26 │  3.7.16 │   2022-12-06   │ 2023-06-27 │
│  3.6  │ 2016-12-22 │  3.6.15 │   2021-09-03   │ 2021-12-23 │
│  3.5  │ 2015-09-12 │  3.5.10 │   2020-09-05   │ 2020-09-13 │
│  3.4  │ 2014-03-15 │  3.4.10 │   2019-03-18   │ 2019-03-18 │
│  3.3  │ 2012-09-29 │  3.3.7  │   2017-09-19   │ 2017-09-29 │
│  2.7  │ 2010-07-03 │  2.7.18 │   2020-04-19   │ 2020-01-01 │
│  2.6  │ 2008-10-01 │  2.6.9  │   2013-10-29   │ 2013-10-29 │
└───────┴────────────┴─────────┴────────────────┴────────────┘
```

The addition of requires-python is to provide guards to keep older CPython versions from installing releases that could contain unrunnable code.