### PR TITLE
chore: Apply pyupgrade --py36-plus

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,3 @@
-
 name: tests
 #Running tests on all branches
 on:

--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -1,7 +1,4 @@
 """hepdata_lib main."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import shutil
@@ -49,7 +46,7 @@ warnings.filterwarnings("always", category=DeprecationWarning, module="hepdata_l
 
 __version__ = "0.11.1"
 
-class AdditionalResourceMixin(object):
+class AdditionalResourceMixin:
     """Functionality related to additional materials."""
 
     def __init__(self):
@@ -104,7 +101,7 @@ class AdditionalResourceMixin(object):
             helpers.check_file_size(ifile, upper_limit=100)
             shutil.copy2(ifile, outdir)
 
-class Variable(object):
+class Variable:
     """A Variable is a wrapper for a list of values + some meta data."""
 
     # pylint: disable=too-many-instance-attributes
@@ -134,7 +131,7 @@ class Variable(object):
         if self.is_binned:
             # Check that the input is well-formed
             try:
-                assert all((len(x) == 2 for x in value_list))
+                assert all(len(x) == 2 for x in value_list)
             except (AssertionError, TypeError, ValueError) as err:
                 msg = "For binned Variables, values should be tuples of length two: \
                                  (lower bin edge, upper bin edge)."
@@ -189,14 +186,14 @@ class Variable(object):
         is applied on the length of the list of Uncertainty values.
         """
         if not isinstance(uncertainty, Uncertainty):
-            raise TypeError("Expected 'Uncertainty', instead got '{0}'.".format(type(uncertainty)))
+            raise TypeError(f"Expected 'Uncertainty', instead got '{type(uncertainty)}'.")
 
         lenvar = len(self.values)
         lenunc = len(uncertainty.values)
         if lenvar and (lenvar != lenunc):
-            raise ValueError("Length of uncertainty list ({0})" \
+            raise ValueError(f"Length of uncertainty list ({lenunc})" \
                              "is not the same as length of Variable" \
-                             "values list ({1})!.".format(lenunc, lenvar))
+                             f"values list ({lenvar})!.")
         self.uncertainties.append(uncertainty)
 
     def make_dict(self):
@@ -299,7 +296,7 @@ class Table(AdditionalResourceMixin):
         self.description = "Example description"
         self.location = "Example location"
         self.keywords = {}
-        self.image_files = set([])
+        self.image_files = set()
 
     @property
     def name(self):
@@ -334,12 +331,12 @@ class Table(AdditionalResourceMixin):
             warnings.warn(msg, DeprecationWarning)
 
         if not isinstance(file_path, str):
-            raise TypeError("Expected string argument, instead got: '{}'.".format(type(file_path)))
+            raise TypeError(f"Expected string argument, instead got: '{type(file_path)}'.")
         file_path = os.path.expanduser(file_path)
         if os.path.exists(file_path):
             self.image_files.add(file_path)
         else:
-            raise RuntimeError("Cannot find image file: {0}".format(file_path))
+            raise RuntimeError(f"Cannot find image file: {file_path}")
 
     def write_output(self, outdir):
         """
@@ -361,7 +358,7 @@ class Table(AdditionalResourceMixin):
         :type outdir: string
         """
         if not isinstance(outdir, str):
-            raise TypeError("Expected string argument, instead got: '{}'.".format(type(outdir)))
+            raise TypeError(f"Expected string argument, instead got: '{type(outdir)}'.")
 
         for image_file in self.image_files:
             if not os.path.isfile(image_file):
@@ -414,7 +411,7 @@ class Table(AdditionalResourceMixin):
         if isinstance(variable, Variable):
             self.variables.append(variable)
         else:
-            raise TypeError("Unknown object type: {0}".format(str(type(variable))))
+            raise TypeError(f"Unknown object type: {str(type(variable))}")
 
     def write_yaml(self, outdir="."):
         """
@@ -436,7 +433,7 @@ class Table(AdditionalResourceMixin):
 
         shortname = self.name.lower().replace(" ", "_")
         outfile_path = os.path.join(
-            outdir, '{NAME}.yaml'.format(NAME=shortname))
+            outdir, f'{shortname}.yaml')
         with open(outfile_path, 'w') as outfile:
             yaml.dump(table, outfile, default_flow_style=False)
 
@@ -447,7 +444,7 @@ class Table(AdditionalResourceMixin):
             submission["name"] = self.name
             submission["description"] = self.description
             submission["location"] = self.location
-            submission["data_file"] = '{NAME}.yaml'.format(NAME=shortname)
+            submission["data_file"] = f'{shortname}.yaml'
             submission["keywords"] = []
             if self.additional_resources:
                 submission["additional_resources"] = self.additional_resources
@@ -499,7 +496,7 @@ class Submission(AdditionalResourceMixin):
         if isinstance(table, Table):
             self.tables.append(table)
         else:
-            raise TypeError("Unknown object type: {0}".format(str(type(table))))
+            raise TypeError(f"Unknown object type: {str(type(table))}")
 
     def add_link(self, description, location):
         """
@@ -614,7 +611,7 @@ class Submission(AdditionalResourceMixin):
                     full_submission_validator.print_errors(filename)
             assert is_archive_valid, "The tar ball is not valid"
 
-class Uncertainty(object):
+class Uncertainty:
     """
     Store information about an uncertainty on a variable
 

--- a/hepdata_lib/c_file_reader.py
+++ b/hepdata_lib/c_file_reader.py
@@ -6,7 +6,7 @@ from ROOT import TGraph, TGraphErrors
 import hepdata_lib.root_utils as ru
 from hepdata_lib.helpers import check_file_existence
 
-class CFileReader(object):
+class CFileReader:
     """Reads ROOT Objects from .C files"""
 
     def __init__(self, cfile):
@@ -34,7 +34,7 @@ class CFileReader(object):
                     "CFileReader: Input file is not a .C file (name does not end in .C)!"
                     )
             if check_file_existence(cfile):
-                self._cfile = open(cfile, "r") # pylint: disable=consider-using-with
+                self._cfile = open(cfile) # pylint: disable=consider-using-with
         else:
             if isinstance(cfile, io.TextIOBase):
                 self._cfile = cfile
@@ -43,7 +43,7 @@ class CFileReader(object):
                     "CFileReader: Encountered unknown type of variable passed as cfile argument: "
                     + str(type(cfile)))
         if not self._cfile:
-            raise IOError("CFileReader: File not opened properly.")
+            raise OSError("CFileReader: File not opened properly.")
 
     def get_graphs(self):
         """Parse the .C file trying to find TGraph objects"""

--- a/hepdata_lib/helpers.py
+++ b/hepdata_lib/helpers.py
@@ -1,7 +1,4 @@
 """hepdata_lib helper functions."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import subprocess
@@ -43,7 +40,7 @@ def execute_command(command):
 def find_all_matching(path, pattern):
     """Utility function that works like 'find' in bash."""
     if not os.path.exists(path):
-        raise RuntimeError("Invalid path '{0}'".format(path))
+        raise RuntimeError(f"Invalid path '{path}'")
     result = []
     for root, _, files in os.walk(path):
         for thisfile in files:
@@ -63,7 +60,7 @@ def get_number_precision(value):
     """
 
     if isinstance(value, tuple):
-        return tuple((get_number_precision(x) for x in value))
+        return tuple(get_number_precision(x) for x in value)
 
     # if value is tuple, value == 0 might cause ValueError saying that
     # 'The truth value of an array with more than one element is ambiguous'
@@ -78,7 +75,7 @@ def relative_round(value, relative_digits):
     """Rounds to a given relative precision"""
 
     if isinstance(value, tuple):
-        return tuple((relative_round(x, relative_digits) for x in value))
+        return tuple(relative_round(x, relative_digits) for x in value)
 
     if value == 0 or isinstance(value, str) or np.isnan(value) or np.isinf(value):
         return value
@@ -243,11 +240,11 @@ def check_file_size(path_to_file, upper_limit=None, lower_limit=None):
     """
     size = 1e-6 * os.path.getsize(path_to_file)
     if upper_limit and size > upper_limit:
-        raise RuntimeError("File too big: '{0}'. Maximum allowed value is {1} \
-                            MB.".format(path_to_file, upper_limit))
+        raise RuntimeError(f"File too big: '{path_to_file}'. Maximum allowed value is {upper_limit}"
+        + "MB.")
     if lower_limit and size < lower_limit:
-        raise RuntimeError("File too small: '{0}'. Minimal allowed value is {1} \
-                            MB.".format(path_to_file, lower_limit))
+        raise RuntimeError(f"File too small: '{path_to_file}'."
+        + f"Minimal allowed value is {lower_limit} MB.")
 
 
 def any_uncertainties_nonzero(uncertainties, size):

--- a/hepdata_lib/root_utils.py
+++ b/hepdata_lib/root_utils.py
@@ -6,7 +6,7 @@ import numpy as np
 import ROOT as r
 from hepdata_lib.helpers import check_file_existence
 
-class RootFileReader(object):
+class RootFileReader:
     """Easily extract information from ROOT histograms, graphs, etc"""
 
     def __init__(self, tfile):
@@ -46,7 +46,7 @@ class RootFileReader(object):
                 + str(type(tfile)))
 
         if not self._tfile:
-            raise IOError("RootReader: File not opened properly.")
+            raise OSError("RootReader: File not opened properly.")
 
     def retrieve_object(self, path_to_object):
         """
@@ -85,11 +85,9 @@ class RootFileReader(object):
                     return entry
 
             # Didn't find anything. Print available primitives to help user debug.
-            print("Available primitives in TCanvas '{0}':".format(
-                path_to_canvas))
+            print(f"Available primitives in TCanvas '{path_to_canvas}':")
             for entry in list(canv.GetListOfPrimitives()):
-                print("Name: '{0}', Type: '{1}'.".format(
-                    entry.GetName(), type(entry)))
+                print(f"Name: '{entry.GetName()}', Type: '{type(entry)}'.")
             assert False
 
         except AssertionError:
@@ -106,13 +104,17 @@ class RootFileReader(object):
 
             return obj
         except AssertionError as err:
-            msg="Cannot find any object in file {0} using path {1} or interpreting it as a TCanvas"\
-                "with TPads.".format(self.tfile, path_to_object)
+            msg = (
+                f"Cannot find any object in file {self.tfile} using path {path_to_object} or"
+                + " interpreting it as a TCanvas with TPads."
+            )
             raise_from(IOError(msg), err)
 
         except AttributeError as err:
-            msg="Cannot find any object in file {0} using path {1} or interpreting it as a TCanvas"\
-                "with TPads.".format(self.tfile, path_to_object)
+            msg = (
+                f"Cannot find any object in file {self.tfile} using path {path_to_object} or"
+                + " interpreting it as a TCanvas with TPads."
+            )
             raise_from(IOError(msg), err)
 
         return None
@@ -216,13 +218,13 @@ class RootFileReader(object):
         """
         tree = self.tfile.Get(path_to_tree)
         if not tree or not isinstance(tree, r.TTree):
-            raise RuntimeError("No TTree found for path '{0}'.".format(path_to_tree))
+            raise RuntimeError(f"No TTree found for path '{path_to_tree}'.")
         values = []
         for event in tree:
             try:
                 values.append(getattr(event, branch_name))
             except AttributeError as err:
-                msg = "The TTree does not have a branch with name '{0}'.".format(branch_name)
+                msg = f"The TTree does not have a branch with name '{branch_name}'."
                 raise_from(RuntimeError(msg),err)
         return values
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 """pypi package setup."""
-from __future__ import print_function
 import codecs
 from os import path
 from setuptools import setup, find_packages
@@ -8,7 +7,7 @@ try:
 except ImportError:
     print("ROOT is required by this library.")
 
-with open("requirements.txt","r") as f:
+with open("requirements.txt") as f:
     DEPS = f.readlines()
 
 HERE = path.abspath(path.dirname(__file__))

--- a/tests/test_cfilereader.py
+++ b/tests/test_cfilereader.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
-# -*- coding:utf-8 -*-
 """Test CFileReader."""
-from __future__ import print_function
 from unittest import TestCase
 import os
 import numpy as np
@@ -56,7 +54,7 @@ class TestCFileReader(TestCase):
 
         # Use opened file (io.TextIOBase)
         try:
-            with open(_cfile, "r") as testfile:
+            with open(_cfile) as testfile:
                 _reader = CFileReader(testfile)
         # pylint: disable=W0702
         except:
@@ -167,7 +165,7 @@ class TestCFileReader(TestCase):
 
         reader = CFileReader(test_file)
         tgraphs = reader.get_graphs()
-        self.assertTrue(set(tgraphs.keys()) == set(["tgraph", "tgraph"]))
+        self.assertTrue(set(tgraphs.keys()) == {"tgraph", "tgraph"})
 
         self.addCleanup(os.remove, test_file)
         self.doCleanups()
@@ -188,7 +186,7 @@ class TestCFileReader(TestCase):
         reader = CFileReader(c_file)
         graph = reader.create_tgrapherrors(x_value, y_value, dx_value, dy_value)
 
-        self.assertTrue(set(graph.keys()) == set(["x", "y", "dx", "dy"]))
+        self.assertTrue(set(graph.keys()) == {"x", "y", "dx", "dy"})
         self.assertTrue(all(graph["x"] == x_value))
         self.assertTrue(all(graph["y"] == y_value))
 
@@ -217,7 +215,7 @@ class TestCFileReader(TestCase):
         reader = CFileReader(c_file)
         graph = reader.create_tgraph(x_value, y_value)
 
-        self.assertTrue(set(graph.keys()) == set(["x", "y"]))
+        self.assertTrue(set(graph.keys()) == {"x", "y"})
         self.assertTrue(all(graph["x"] == x_value))
         self.assertTrue(all(graph["y"] == y_value))
         self.addCleanup(os.remove, c_file)

--- a/tests/test_execute_command.py
+++ b/tests/test_execute_command.py
@@ -1,5 +1,4 @@
 # !/usr/bin/env python
-# -*- coding:utf-8 -*-
 """Test execute_command() function."""
 from unittest import TestCase
 from hepdata_lib.helpers import execute_command

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding:utf-8 -*-
 """Test helpers."""
 from unittest import TestCase
 

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -9,8 +9,8 @@ def common_kwargs(tmpdir):
     outputnb = tmpdir.join('output.ipynb')
     return {
         'output_path': str(outputnb),
-        'kernel_name': 'python{}'.format(sys.version_info.major),
-        'cwd' : str('examples')
+        'kernel_name': f'python{sys.version_info.major}',
+        'cwd' : 'examples'
     }
 
 def test_correlation(common_kwargs):# pylint: disable=redefined-outer-name

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,7 +1,5 @@
 # !/usr/bin/env python
-# -*- coding:utf-8 -*-
 """Test Output."""
-from __future__ import print_function
 from collections import defaultdict
 from unittest import TestCase
 import shutil
@@ -38,7 +36,7 @@ class TestOutput(TestCase):
         # Test read yaml file
         table_file = os.path.join(tmp_dir, "testtable.yaml")
         try:
-            with open(table_file, 'r') as testfile:
+            with open(table_file) as testfile:
                 testyaml = yaml.safe_load(testfile)
         except yaml.YAMLError as exc:
             print(exc)
@@ -47,7 +45,7 @@ class TestOutput(TestCase):
         testtxt = ("dependent_variables:\n- header:\n    name: Y\n  values:\n" +
                    "  - value: 0.12\n  - value: 0.22\nindependent_variables:\n" +
                    "- header:\n    name: X\n  values:\n  - value: 1.2\n  - value: 2.2\n")
-        with open(table_file, 'r') as testfile:
+        with open(table_file) as testfile:
             testyaml = testfile.read()
 
         self.assertEqual(str(testyaml), testtxt)

--- a/tests/test_rootfilereader.py
+++ b/tests/test_rootfilereader.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
-# -*- coding:utf-8 -*-
 """Test RootFileReader."""
-from __future__ import print_function
 from unittest import TestCase
 from array import array
 import os
@@ -79,7 +77,7 @@ class TestRootFileReader(TestCase):
         reader = RootFileReader(testfile.GetName())
         data = reader.read_graph(name)
 
-        self.assertTrue(set(data.keys()) == set(["x", "y"]))
+        self.assertTrue(set(data.keys()) == {"x", "y"})
         self.assertTrue(all(data["x"] == x))
         self.assertTrue(all(data["y"] == y))
 
@@ -398,8 +396,8 @@ class TestRootFileReader(TestCase):
         NX = 13
         NY = 37
         y_values = np.random.uniform(-1e3, 1e3, (NX,NY))
-        xlabels = ["X{0}".format(i) for i in range(NX)]
-        ylabels = ["Y{0}".format(i) for i in range(NY)]
+        xlabels = [f"X{i}" for i in range(NX)]
+        ylabels = [f"Y{i}" for i in range(NY)]
 
         hist = ROOT.TH2D("test2d_labels", "test2d_labels", NX, 0, NX, NY, 0, NY)
         for i in range(NX):
@@ -717,8 +715,8 @@ class TestRootFileReader(TestCase):
         except RuntimeError:
             self.fail("RootFileReader.read_tree raised an unexpected RuntimeError!")
         self.assertIsInstance(data_readback, list)
-        self.assertTrue(all((float_compare(values[0], values[1])
-                             for values in zip(data, data_readback))))
+        self.assertTrue(all(float_compare(values[0], values[1])
+                             for values in zip(data, data_readback)))
 
         # Try reading a nonexistant branch from an existing tree
         with self.assertRaises(RuntimeError):
@@ -766,7 +764,7 @@ class TestRootFileReader(TestCase):
         reader = RootFileReader(path_to_file)
         try:
             readback = reader.retrieve_object("canvas/testhist")
-        except IOError:
+        except OSError:
             print("RootFileReader.retrieve_object raised unexpected IOError!")
             self.fail()
 
@@ -808,7 +806,7 @@ class TestRootFileReader(TestCase):
         reader = RootFileReader(path_to_file)
         try:
             readback = reader.retrieve_object(path_to_object)
-        except IOError:
+        except OSError:
             print("RootFileReader.retrieve_object raised unexpected IOError!")
             self.fail()
 

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -1,10 +1,8 @@
 # !/usr/bin/env python
-# -*- coding:utf-8 -*-
 """Test Submission."""
 import os
 import shutil
 import string
-from builtins import bytes
 from unittest import TestCase
 import tarfile
 from test_utilities import tmp_directory_name

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,5 +1,4 @@
 # !/usr/bin/env python
-# -*- coding:utf-8 -*-
 """Test Table."""
 import os
 import shutil

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding:utf-8 -*-
 """Test Uncertainty."""
 import random
 from unittest import TestCase

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding:utf-8 -*-
 """Utilities for tests."""
 
 import os
@@ -105,7 +104,7 @@ def make_tmp_root_file(path_to_file='tmp_{RANDID}.root', mode="RECREATE",
     rfile = ROOT.TFile(path_to_file, mode)
 
     if not rfile:
-        raise RuntimeError("Failed to create temporary file: {}".format(path_to_file))
+        raise RuntimeError(f"Failed to create temporary file: {path_to_file}")
 
     if testcase:
         testcase.addCleanup(remove_if_exist, path_to_file)

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding:utf-8 -*-
 """Test Variable."""
 import random
 from unittest import TestCase


### PR DESCRIPTION
Now that `hepdata_lib` is Python 3.6+, apply some code cleaning by upgrading all syntax to use modern Python that is Python 3.6+ compliant by applying `pyupgrade --py36-plus` to the codebase.

Requires PR #221 to go in first.