### PR TITLE
Add sphinx.ext.imgconverter extension to make SVGs build in LateX

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,6 +84,9 @@ language = 'en'
 # This pattern also affects html_static_path and html_extra_path .
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+# Suppress warnings for unknown epub files (.nojekyll)
+suppress_warnings = ['epub.unknown_project_files']
+
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,8 @@ release = '0.13.0'
 extensions = [
     'sphinx.ext.githubpages',
     'sphinx_mdinclude',
-    'sphinx.ext.autodoc'
+    'sphinx.ext.autodoc',
+    'sphinx.ext.imgconverter',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -110,6 +110,7 @@ After installing the ``hepdata_lib`` package, move into the ``hepdata_lib/docs``
     pip install -r requirements.txt
 
 Then you can build the documentation locally with Sphinx using ``make html`` and view the output by opening a web browser at ``_build/html/index.html``.
+In addition, please also test whether building the LateX (``make latexpdf``) and epub (``make epub``) versions works.
 
 
 Analysing the code


### PR DESCRIPTION
Docs are failing to build because there's no SVG support, see an example log at https://readthedocs.org/api/v2/build/22295173.txt

This is an attempt to fix the issue, following https://github.com/sphinx-doc/sphinx/issues/1907

<!-- readthedocs-preview hepdata-lib start -->
----
:books: Documentation preview :books:: https://hepdata-lib--240.org.readthedocs.build/en/240/

<!-- readthedocs-preview hepdata-lib end -->