### PR TITLE
Update docs to use Apptainer instead of Singularity

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It is highly recommended you install `hepdata_lib` into a [virtual environment](
 pip install hepdata_lib
 ```
 
-If you are not sure about your Python environment, please also see below how to use `hepdata_lib` in a Docker or Singularity container.
+If you are not sure about your Python environment, please also see below how to use `hepdata_lib` in a Docker or Apptainer container.
 
 ## Getting started
 
@@ -44,11 +44,11 @@ If you prefer a shell, instead run:
 docker run --rm -it -p 8888:8888 -v ${PWD}:/home/hepdata ghcr.io/hepdata/hepdata_lib:latest bash
 ```
 
-If on CERN LXPLUS or anywhere else where there is Singularity available but not Docker, you can still use the docker image:
+If on CERN LXPLUS or anywhere else where there is Apptainer available but not Docker, you can still use the docker image:
 
 ```shell
-export SINGULARITY_CACHEDIR="/tmp/$(whoami)/singularity"
-singularity shell -B /afs -B /eos docker://ghcr.io/hepdata/hepdata_lib:latest bash
+export APPTAINER_CACHEDIR="/tmp/$(whoami)/apptainer"
+apptainer shell -B /afs -B /eos docker://ghcr.io/hepdata/hepdata_lib:latest bash
 ```
 
 Unpacking the image can take a few minutes the first time you use it. Please be patient. Both EOS and AFS should be available and the output will be in your current working directory.

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -22,17 +22,17 @@ If you are running on your own computer or laptop, it's up to you to decide wher
 
 This setup naturally restricts you to use the latest stable version of the package in pypi. If you would like to use the code as it is the github repository, please follow the instructions in :ref:`sec-setup-developers`.
 
-Using Singularity/Apptainer
+Using Apptainer
 +++++++++++++++++++++++++++++++
 
-On LXPLUS and many other local computing sites with CVMFS and Singularity/Apptainer available, you can use the library without having to install anything:
+On LXPLUS and many other local computing sites with CVMFS and Apptainer (previously called Singularity) available, you can use the library without having to install anything:
 
 ::
 
     apptainer run /cvmfs/unpacked.cern.ch/ghcr.io/hepdata/hepdata_lib:latest /bin/bash
 
 This opens a new shell with ``hepdata_lib``, ROOT, and Python 3 available.
-Your home directory and most other user directories on the machine on which you execute Singularity/Apptainer will also be accessible from within this shell.
+Your home directory and most other user directories on the machine on which you execute Apptainer will also be accessible from within this shell.
 
 
 .. _sec-setup-developers:
@@ -119,7 +119,7 @@ After running ``cmsenv``, you can check the installed version as follows:
 
 (mind the use of ``hepdata-lib`` above, when importing, the package is still
 called ``hepdata_lib``). If the version is significantly older than the one
-on PyPI_, please use the Singularity/Apptainer container as described at
+on PyPI_, please use the Apptainer container as described at
 :ref:`sec-setup-users` above.
 
 .. _cmsdist: https://github.com/cms-sw/cmsdist/


### PR DESCRIPTION
By now most sites will have moved to Apptainer and even though `singularity` is typically soft-linked to `apptainer`, using `SINGULARITY_CACHEDIR` instead of `APPTAINER_CACHEDIR` will lead to a warning, so updating the docs is better.

<!-- readthedocs-preview hepdata-lib start -->
----
:books: Documentation preview :books:: https://hepdata-lib--244.org.readthedocs.build/en/244/

<!-- readthedocs-preview hepdata-lib end -->