### PR TITLE
Migrate test action to setup-micromamba and fix upload-artifact

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,7 +105,7 @@ jobs:
       if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:
-        name: notebooks py3
+        name: notebooks-${{ matrix.root-version }}-${{ matrix.python-version }}-${{ matrix.os }} py3-${{ matrix.root-version }}-${{ matrix.python-version }}-${{ matrix.os }}
         path: examples/*.html
 
     - name: Run pylint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,17 +47,18 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup Micromamba environment
-      uses: mamba-org/provision-with-micromamba@v16
+      uses: mamba-org/setup-micromamba@v1
       with:
-        environment-file: false
         environment-name: ci
-        extra-specs: |
+        create-args: >-
           python=${{ matrix.python-version }}
           root=${{ matrix.root-version }}
           imagemagick
           ghostscript
           pip
-        channels: conda-forge
+        condarc: |
+          channels:
+            - conda-forge
 
     - name: ROOT info
       run: |


### PR DESCRIPTION
Following https://github.com/mamba-org/provision-with-micromamba?tab=readme-ov-file#example-2-micromamba-version-environment-file-false-channels

Also fixes upload-artifact https://github.com/actions/upload-artifact/tree/v4/?tab=readme-ov-file#not-uploading-to-the-same-artifact

<!-- readthedocs-preview hepdata-lib start -->
----
📚 Documentation preview 📚: https://hepdata-lib--249.org.readthedocs.build/en/249/

<!-- readthedocs-preview hepdata-lib end -->