### PR TITLE
Enable trusted publishing workflow to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+    pypi-publish:
+        name: upload release to PyPI
+        runs-on: ubuntu-latest
+        # Specifying a GitHub environment is optional, but strongly encouraged
+        environment: release
+        permissions:
+            # IMPORTANT: this permission is mandatory for trusted publishing
+            id-token: write
+        steps:
+            # retrieve your distributions here
+        - uses: actions/checkout@v4
+        - name: Set up Python
+          uses: actions/setup-python@v5
+          with:
+            python-version: '3.11'
+            cache: pip
+            cache-dependency-path: '**/pyproject.toml'
+        - name: Install dependencies
+          run: |
+            pip install setuptools wheel build
+        - name: Build
+          run: |
+            python -m build
+        - name: Publish
+          uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Fixes #165 

I've added the workflow in PyPI and created the "release" environment following https://til.simonwillison.net/pypi/pypi-releases-from-github

<img width="749" alt="image" src="https://github.com/HEPData/hepdata_lib/assets/5270053/fa6f514b-e7b9-47af-8fe0-8b7aeb1bf4c9">

<!-- readthedocs-preview hepdata-lib start -->
----
📚 Documentation preview 📚: https://hepdata-lib--256.org.readthedocs.build/en/256/

<!-- readthedocs-preview hepdata-lib end -->