### PR TITLE
Update usage.rst to include self-referencing notice

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -155,6 +155,8 @@ To add a link to a related record object, you can use the ``add_related_recid`` 
 
 In the last example, we are adding a link to the submission with the record ID value of ``3``.
 
+**Please note:** This field should not be used for self-referencing, the IDs inserted should be for OTHER related records.
+
 The documentation for this feature can be found here: `Linking records`_.
 
 .. _`Linking records`: https://hepdata-submission.readthedocs.io/en/latest/bidirectional.html#linking-records
@@ -311,6 +313,8 @@ To add a link to a related table object, you can use the ``add_related_doi`` fun
     table.add_related_doi("10.17182/hepdata.12882.v1/t2")
 
 In the second example, we are adding a link to the table with a DOI value of `10.17182/hepdata.12882.v1/t2 <https://doi.org/10.17182/hepdata.12882.v1/t2>`_.
+
+**Please note:** This field should not be used for self-referencing, the DOIs inserted should be for OTHER related tables.
 
 The documentation for this feature can be found here: `Linking tables`_.
 


### PR DESCRIPTION
Updates the bidirectional linking documentation for records/tables to note that the intended use for the field is not for self-referencing as mentioned in [HEPData/hepdata Issue 765](https://github.com/HEPData/hepdata/issues/765)

<!-- readthedocs-preview hepdata-lib start -->
----
📚 Documentation preview 📚: https://hepdata-lib--258.org.readthedocs.build/en/258/

<!-- readthedocs-preview hepdata-lib end -->