### PR TITLE
Add support for inhomogenous error breakdowns

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -370,5 +370,7 @@ multiple dependent variables and a (different) subset of the bins has missing co
 In this case the uncertainties should be set to zero for the missing bins with a non-numeric central value like ``'-'``.
 The warning message can be suppressed by passing an optional argument ``zero_uncertainties_warning=False`` when
 defining an instance of the ``Variable`` class.
+Furthermore, note that `None` can be used to suppress the uncertainty for individual bins in cases where
+the uncertainty components may only apply to a subset of the values.
 
 .. _`Uncertainties`: https://hepdata-submission.readthedocs.io/en/latest/data_yaml.html#uncertainties

--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -277,6 +277,8 @@ class Variable:
             # if at least one of the uncertainties is not zero.
             if nonzero_uncs[i]:
                 for unc in self.uncertainties:
+                    if unc.values[i] is None:
+                        continue
                     if unc.is_symmetric:
                         valuedict['errors'].append({
                             "symerror":

--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -235,6 +235,7 @@ class Variable:
         self.uncertainties.append(uncertainty)
 
     def make_dict(self):
+        # pylint: disable=too-many-branches
         """
         Return all data in this Variable as a dictionary.
 

--- a/hepdata_lib/helpers.py
+++ b/hepdata_lib/helpers.py
@@ -274,7 +274,7 @@ def sanitize_value(value):
     Handle conversion of input types for internal storage.
 
     :param value: User-side input value to sanitize.
-    :type value: string, int, or castable to float
+    :type value: string, int, NoneType, or castable to float
 
     Strings, integers and None are left alone,
     everything else is converted to float.

--- a/hepdata_lib/helpers.py
+++ b/hepdata_lib/helpers.py
@@ -283,6 +283,8 @@ def sanitize_value(value):
         return value
     if isinstance(value,int):
         return value
+    if value is None:
+        return value
     return float(value)
 
 

--- a/hepdata_lib/helpers.py
+++ b/hepdata_lib/helpers.py
@@ -276,7 +276,7 @@ def sanitize_value(value):
     :param value: User-side input value to sanitize.
     :type value: string, int, or castable to float
 
-    Strings and integers are left alone,
+    Strings, integers and None are left alone,
     everything else is converted to float.
     """
     if isinstance(value,str):

--- a/hepdata_lib/helpers.py
+++ b/hepdata_lib/helpers.py
@@ -258,7 +258,8 @@ def any_uncertainties_nonzero(uncertainties, size):
     for unc in uncertainties:
 
         # Treat one-sided uncertainties as
-        values = np.array(unc.values)
+        tmp = 0 if unc.is_symmetric else (0,0)
+        values = np.array([tmp if v is None else v for v in unc.values])
         values[values.astype(str)==''] = 0
         values = values.astype(float)
 

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -120,12 +120,12 @@ class TestUncertainty(TestCase):
         '''Test cases where an uncertainty only applies to a subset of the bins'''
         var = Variable("testvar", is_independent=False, is_binned=False, values=[1,2,3],
                        zero_uncertainties_warning=False)
-        uncA = Uncertainty('errorA', is_symmetric=True)
-        uncA.values = [ 0.1, 0.2, None ]
-        var.add_uncertainty(uncA)
-        uncB = Uncertainty('errorB', is_symmetric=True)
-        uncB.values = [ 0.1, 0.2, 0.3 ]
-        var.add_uncertainty(uncB)
+        unc_a = Uncertainty('errorA', is_symmetric=True)
+        unc_a.values = [ 0.1, 0.2, None ]
+        var.add_uncertainty(unc_a)
+        unc_b = Uncertainty('errorB', is_symmetric=True)
+        unc_b.values = [ 0.1, 0.2, 0.3 ]
+        var.add_uncertainty(unc_b)
         dictionary = var.make_dict()
         self.assertTrue(len([ errs['label'] for i in [0,1,2] \
                                             for errs in dictionary['values'][i]['errors'] \

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -115,3 +115,18 @@ class TestUncertainty(TestCase):
         # Check that 'errors' key is missing only if zero uncertainties
         self.assertTrue(all('errors' in dictionary['values'][i] for i in [0, 1, 3]))
         self.assertTrue('errors' not in dictionary['values'][2])
+
+    def test_inhomogenous_uncertainties(self):
+        '''Test cases where an uncertainty only applies to a subset of the bins'''
+        var = Variable("testvar", is_independent=False, is_binned=False, values=[1,2,3],
+                       zero_uncertainties_warning=False)
+        uncA = Uncertainty('errorA', is_symmetric=True)
+        uncA.values = [ 0.1, 0.2, None ]
+        var.add_uncertainty(uncA)
+        uncB = Uncertainty('errorB', is_symmetric=True)
+        uncB.values = [ 0.1, 0.2, 0.3 ]
+        var.add_uncertainty(uncB)
+        dictionary = var.make_dict()
+        self.assertTrue(len([ errs['label'] for i in [0,1,2] \
+                                            for errs in dictionary['values'][i]['errors'] \
+                                            if errs['label'] == 'errorA'])==2)


### PR DESCRIPTION
Proposal solution for the feature discussed in #229 :

The HepData validator already allows for cases where different bins have different error breakdowns, but `hepdata_lib` currently does not support this.

With this change set one can suppress individual sources by setting them to `None`.

Closes #266.

<!-- readthedocs-preview hepdata-lib start -->
----
📚 Documentation preview 📚: https://hepdata-lib--265.org.readthedocs.build/en/265/

<!-- readthedocs-preview hepdata-lib end -->