### PR TITLE
Use separate Pylint steps in CI for `hepdata_lib` and `tests` directories

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,8 +141,12 @@ jobs:
         name: notebooks-${{ matrix.root-version }}-${{ matrix.python-version }}-${{ matrix.os }} py3-${{ matrix.root-version }}-${{ matrix.python-version }}-${{ matrix.os }}
         path: examples/*.html
 
-    - name: Run pylint
+    - name: Run pylint on hepdata_lib
       if: ${{ always() && !startsWith(matrix.python-version, '3.6') && !startsWith(matrix.python-version, '3.7') }}
       run: |
         python -m pylint hepdata_lib/*.py
+
+    - name: Run pylint on tests
+      if: ${{ always() && !startsWith(matrix.python-version, '3.6') && !startsWith(matrix.python-version, '3.7') }}
+      run: |
         python -m pylint tests/*.py


### PR DESCRIPTION
https://github.com/HEPData/hepdata_lib/blob/ba9f2e28e33e59bb2bf5b429cab97d31cd556538/.github/workflows/tests.yml#L144-L148

I noticed in PR #265 that the CI is successful for commit 81adb429876820762c6b8608b9f36cc69d1040e9 ([workflow run](https://github.com/HEPData/hepdata_lib/actions/runs/10041588892)) despite the command `python -m pylint hepdata_lib/*.py` giving a exit code 8 with a message:
```
************* Module hepdata_lib
hepdata_lib/__init__.py:237:4: R0912: Too many branches (13/12) (too-many-branches)

-----------------------------------
Your code has been rated at 9.99/10
```
Thus it looks like only the second command `python -m pylint tests/*.py` giving `Your code has been rated at 10.00/10` (exit code 0) determines whether the "Run pylint" step passes or fails.  The subsequent commit 51f13c107270af2c7c3ba6aec561f9701683ce06 ([workflow run](https://github.com/HEPData/hepdata_lib/actions/runs/10045919576)) gives issues for both the `hepdata_lib` and `tests` directories and the "Run pylint" step fails.  This PR therefore separates the single "Run pylint" step into separate steps for the `hepdata_lib` and `tests` directories so that a code rating less than 10.00/10 (corresponding to a non-zero exit code for `pylint`) for either directory will result in the CI failing.

<!-- readthedocs-preview hepdata-lib start -->
----
📚 Documentation preview 📚: https://hepdata-lib--267.org.readthedocs.build/en/267/

<!-- readthedocs-preview hepdata-lib end -->