### PR TITLE
Remove warning importing ROOT in `root_utils.py` and expand test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,8 +76,8 @@ jobs:
             python-version: "3.8"
         include:
           - os: macos-latest
-            root-version: "6.30"
-            python-version: "3.11"
+            root-version: "6.34"
+            python-version: "3.13"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -170,11 +170,11 @@ jobs:
         path: examples/*.html
 
     - name: Run pylint on hepdata_lib
-      if: ${{ always() && matrix.root-version && !startsWith(matrix.python-version, '3.6') && !startsWith(matrix.python-version, '3.7') }}
+      if: ${{ always() && !startsWith(matrix.python-version, '3.6') && !startsWith(matrix.python-version, '3.7') }}
       run: |
         python -m pylint hepdata_lib/*.py
 
     - name: Run pylint on tests
-      if: ${{ always() && matrix.root-version && !startsWith(matrix.python-version, '3.6') && !startsWith(matrix.python-version, '3.7') }}
+      if: ${{ always() && !startsWith(matrix.python-version, '3.6') && !startsWith(matrix.python-version, '3.7') }}
       run: |
         python -m pylint tests/*.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,27 +25,55 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        root-version: ["", "6.24", "6.26", "6.28", "6.30"]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        root-version: ["", "6.24", "6.26", "6.28", "6.30", "6.32", "6.34"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
           - root-version: "6.24"
             python-version: "3.10"
           - root-version: "6.24"
             python-version: "3.11"
+          - root-version: "6.24"
+            python-version: "3.12"
+          - root-version: "6.24"
+            python-version: "3.13"
           - root-version: "6.26"
             python-version: "3.6"
           - root-version: "6.26"
             python-version: "3.7"
           - root-version: "6.26"
             python-version: "3.11"
+          - root-version: "6.26"
+            python-version: "3.12"
+          - root-version: "6.26"
+            python-version: "3.13"
           - root-version: "6.28"
             python-version: "3.6"
           - root-version: "6.28"
             python-version: "3.7"
+          - root-version: "6.28"
+            python-version: "3.12"
+          - root-version: "6.28"
+            python-version: "3.13"
           - root-version: "6.30"
             python-version: "3.6"
           - root-version: "6.30"
             python-version: "3.7"
+          - root-version: "6.30"
+            python-version: "3.12"
+          - root-version: "6.30"
+            python-version: "3.13"
+          - root-version: "6.32"
+            python-version: "3.6"
+          - root-version: "6.32"
+            python-version: "3.7"
+          - root-version: "6.32"
+            python-version: "3.8"
+          - root-version: "6.34"
+            python-version: "3.6"
+          - root-version: "6.34"
+            python-version: "3.7"
+          - root-version: "6.34"
+            python-version: "3.8"
         include:
           - os: macos-latest
             root-version: "6.30"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -170,11 +170,11 @@ jobs:
         path: examples/*.html
 
     - name: Run pylint on hepdata_lib
-      if: ${{ always() && !startsWith(matrix.python-version, '3.6') && !startsWith(matrix.python-version, '3.7') }}
+      if: ${{ always() && matrix.root-version && !startsWith(matrix.python-version, '3.6') && !startsWith(matrix.python-version, '3.7') }}
       run: |
         python -m pylint hepdata_lib/*.py
 
     - name: Run pylint on tests
-      if: ${{ always() && !startsWith(matrix.python-version, '3.6') && !startsWith(matrix.python-version, '3.7') }}
+      if: ${{ always() && matrix.root-version && !startsWith(matrix.python-version, '3.6') && !startsWith(matrix.python-version, '3.7') }}
       run: |
         python -m pylint tests/*.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # output from examples
 examples/submission.tar.gz
 examples/example_output/
+examples/example_output_hist/
 examples/output/
-examples/plots/
 examples/correlation.root
 
 # test output

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 examples/submission.tar.gz
 examples/example_output/
 examples/output/
+examples/plots/
 examples/correlation.root
 
 # test output

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Library for getting your data into HEPData
 
 - Documentation: https://hepdata-lib.readthedocs.io
 
-This code works with Python 3.6, 3.7, 3.8, 3.9, 3.10, 3.11 or 3.12.
+This code works with Python 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12 or 3.13.
 
 ## Installation
 

--- a/hepdata_lib/c_file_reader.py
+++ b/hepdata_lib/c_file_reader.py
@@ -2,6 +2,10 @@
 import io
 from array import array
 from future.utils import raise_from
+try:
+    from ROOT import TGraph, TGraphErrors  # pylint: disable=no-name-in-module
+except ImportError as e:  # pragma: no cover
+    print(f'Cannot import ROOT: {str(e)}')
 import hepdata_lib.root_utils as ru
 from hepdata_lib.helpers import check_file_existence
 
@@ -133,8 +137,6 @@ class CFileReader:
     def create_tgrapherrors(self, x_value, y_value, dx_value, dy_value):
         """Function to create pyroot TGraphErrors object"""
 
-        from ROOT import TGraphErrors  # pylint: disable=import-outside-toplevel, no-name-in-module
-
         # Creating pyroot TGraphErrors object
         x_values = array('i')
         y_values = array('i')
@@ -169,8 +171,6 @@ class CFileReader:
 
     def create_tgraph(self, x_value, y_value):
         """Function to create pyroot TGraph object"""
-
-        from ROOT import TGraph  # pylint: disable=import-outside-toplevel, no-name-in-module
 
         # Creating pyroot TGraph object
         x_values = array('i')

--- a/hepdata_lib/c_file_reader.py
+++ b/hepdata_lib/c_file_reader.py
@@ -2,10 +2,6 @@
 import io
 from array import array
 from future.utils import raise_from
-try:
-    from ROOT import TGraph, TGraphErrors  # pylint: disable=no-name-in-module
-except ImportError as e:  # pragma: no cover
-    print(f'Cannot import ROOT: {str(e)}')
 import hepdata_lib.root_utils as ru
 from hepdata_lib.helpers import check_file_existence
 
@@ -137,6 +133,8 @@ class CFileReader:
     def create_tgrapherrors(self, x_value, y_value, dx_value, dy_value):
         """Function to create pyroot TGraphErrors object"""
 
+        from ROOT import TGraphErrors  # pylint: disable=import-outside-toplevel, no-name-in-module
+
         # Creating pyroot TGraphErrors object
         x_values = array('i')
         y_values = array('i')
@@ -171,6 +169,8 @@ class CFileReader:
 
     def create_tgraph(self, x_value, y_value):
         """Function to create pyroot TGraph object"""
+
+        from ROOT import TGraph  # pylint: disable=import-outside-toplevel, no-name-in-module
 
         # Creating pyroot TGraph object
         x_values = array('i')

--- a/hepdata_lib/root_utils.py
+++ b/hepdata_lib/root_utils.py
@@ -6,7 +6,7 @@ import numpy as np
 try:
     import ROOT as r
 except ImportError as e:  # pragma: no cover
-    print(f'Cannot import ROOT: {str(e)}')
+    pass
 from hepdata_lib.helpers import check_file_existence
 
 class RootFileReader:

--- a/hepdata_lib/root_utils.py
+++ b/hepdata_lib/root_utils.py
@@ -3,6 +3,10 @@ from collections import defaultdict
 import ctypes
 from future.utils import raise_from
 import numpy as np
+try:
+    import ROOT as r
+except ImportError as e:  # pragma: no cover
+    print(f'Cannot import ROOT: {str(e)}')
 from hepdata_lib.helpers import check_file_existence
 
 class RootFileReader:
@@ -30,16 +34,14 @@ class RootFileReader:
         Can either be an already open TFile or a path to the file on disk.
         :type tfile: TFile or str
         """
-        from ROOT import TFile  # pylint: disable=import-outside-toplevel, no-name-in-module
-
         if isinstance(tfile, str):
             if not tfile.endswith(".root"):
                 raise RuntimeError(
                     "RootFileReader: Input file is not a ROOT file (name does not end in .root)!"
                     )
             check_file_existence(tfile)
-            self._tfile = TFile(tfile)  # pylint: disable=no-member
-        elif isinstance(tfile, TFile):  # pylint: disable=no-member
+            self._tfile = r.TFile(tfile)  # pylint: disable=no-member
+        elif isinstance(tfile, r.TFile):  # pylint: disable=no-member
             self._tfile = tfile
         else:
             raise ValueError(
@@ -68,8 +70,6 @@ class RootFileReader:
         :type path_to_object: str.
         :returns: TObject -- The object corresponding to the given path.
         """
-        from ROOT import THStack  # pylint: disable=import-outside-toplevel, no-name-in-module
-
         obj = self.tfile.Get(path_to_object)
 
         # If the Get operation was successful, just return
@@ -101,7 +101,7 @@ class RootFileReader:
         try:
             obj = self.tfile.Get(parts[0])
             for part in parts[1:]:
-                if isinstance(obj, THStack):  # pylint: disable=no-member
+                if isinstance(obj,r.THStack):  # pylint: disable=no-member
                     obj = obj.GetHists().FindObject(part)
                 else:
                     obj = obj.GetPrimitive(part)
@@ -222,10 +222,8 @@ class RootFileReader:
         :returns: list -- The values saved in the tree branch.
 
         """
-        from ROOT import TTree  # pylint: disable=import-outside-toplevel, no-name-in-module
-
         tree = self.tfile.Get(path_to_tree)
-        if not tree or not isinstance(tree, TTree):  # pylint: disable=no-member
+        if not tree or not isinstance(tree, r.TTree):  # pylint: disable=no-member
             raise RuntimeError(f"No TTree found for path '{path_to_tree}'.")
         values = []
         for event in tree:
@@ -301,8 +299,6 @@ def get_hist_2d_points(hist, **kwargs):
         Symmetric errors are returned if the histogram error option
         TH1::GetBinErrorOption() returns TH1::kNormal.
     """
-    from ROOT import TH1  # pylint: disable=import-outside-toplevel, no-name-in-module
-
     xlim = kwargs.pop('xlim', (None, None))
     ylim = kwargs.pop('ylim', (None, None))
     force_symmetric_errors = kwargs.pop('force_symmetric_errors', False)
@@ -327,7 +323,7 @@ def get_hist_2d_points(hist, **kwargs):
     ixmax = hist.GetXaxis().FindBin(xlim[1]) if xlim[1] is not None else hist.GetNbinsX() + 1
     iymin = hist.GetYaxis().FindBin(ylim[0]) if ylim[0] is not None else 1
     iymax = hist.GetYaxis().FindBin(ylim[1]) if ylim[1] is not None else hist.GetNbinsY() + 1
-    symmetric = hist.GetBinErrorOption() == TH1.kNormal  # pylint: disable=no-member
+    symmetric = hist.GetBinErrorOption() == r.TH1.kNormal  # pylint: disable=no-member
     if force_symmetric_errors:
         symmetric = True
     for x_bin in range(ixmin, ixmax):
@@ -384,8 +380,6 @@ def get_hist_1d_points(hist, **kwargs):
         Symmetric errors are returned if the histogram error option
         TH1::GetBinErrorOption() returns TH1::kNormal.
     """
-    from ROOT import TH1  # pylint: disable=import-outside-toplevel, no-name-in-module
-
     xlim = kwargs.pop('xlim', (None, None))
     force_symmetric_errors = kwargs.pop('force_symmetric_errors', False)
     if kwargs:
@@ -400,7 +394,7 @@ def get_hist_1d_points(hist, **kwargs):
     for key in ["x", "y", "x_edges", "x_labels", "dy"]:
         points[key] = []
 
-    symmetric = hist.GetBinErrorOption() == TH1.kNormal  # pylint: disable=no-member
+    symmetric = hist.GetBinErrorOption() == r.TH1.kNormal  # pylint: disable=no-member
     if force_symmetric_errors:
         symmetric = True
     ixmin = hist.GetXaxis().FindBin(xlim[0]) if xlim[0] is not None else 1
@@ -440,10 +434,9 @@ def get_graph_points(graph):
         For asymmetric errors, a list of tuples of (down,up) values is given.
 
     """
-    from ROOT import TGraph, TGraphErrors, TGraphAsymmErrors  # pylint: disable=import-outside-toplevel, no-name-in-module
 
     # Check input
-    if not isinstance(graph, (TGraph, TGraphErrors, TGraphAsymmErrors)):  # pylint: disable=no-member
+    if not isinstance(graph, (r.TGraph, r.TGraphErrors, r.TGraphAsymmErrors)):  # pylint: disable=no-member
         raise TypeError(f"Expected to input to be TGraph or similar, instead got '{type(graph)}'")
 
     # Extract points
@@ -455,10 +448,10 @@ def get_graph_points(graph):
         graph.GetPoint(i, x_val, y_val)
         points["x"].append(float(x_val.value))
         points["y"].append(float(y_val.value))
-        if isinstance(graph, TGraphErrors):  # pylint: disable=no-member
+        if isinstance(graph, r.TGraphErrors):  # pylint: disable=no-member
             points["dx"].append(graph.GetErrorX(i))
             points["dy"].append(graph.GetErrorY(i))
-        elif isinstance(graph, TGraphAsymmErrors):  # pylint: disable=no-member
+        elif isinstance(graph, r.TGraphAsymmErrors):  # pylint: disable=no-member
             points["dx"].append((-graph.GetErrorXlow(i),
                                  graph.GetErrorXhigh(i)))
             points["dy"].append((-graph.GetErrorYlow(i),

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     keywords='HEPData physics OpenData',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),


### PR DESCRIPTION
* Closes #276.
* The test matrix is also expanded to include ROOT 6.32/6.34 and Python 3.12/3.13.

<!-- readthedocs-preview hepdata-lib start -->
----
📚 Documentation preview 📚: https://hepdata-lib--277.org.readthedocs.build/en/277/

<!-- readthedocs-preview hepdata-lib end -->