### PR TITLE
Remove requirement of the future package

### DIFF
--- a/hepdata_lib/__init__.py
+++ b/hepdata_lib/__init__.py
@@ -9,7 +9,6 @@ from decimal import Decimal
 from re import match as rematch
 import numpy as np
 import yaml
-from future.utils import raise_from
 
 # try to use LibYAML bindings if possible
 try:
@@ -173,7 +172,7 @@ class Variable:
             except (AssertionError, TypeError, ValueError) as err:
                 msg = "For binned Variables, values should be tuples of length two: \
                                  (lower bin edge, upper bin edge)."
-                raise_from(ValueError(msg), err)
+                raise ValueError(msg) from err
 
             # All good
             self._values = [
@@ -187,7 +186,7 @@ class Variable:
             try:
                 parsed_values = [helpers.sanitize_value(x) for x in value_list]
             except (TypeError, ValueError) as err:
-                raise_from(ValueError("Malformed input for unbinned variable: ", value_list),err)
+                raise ValueError("Malformed input for unbinned variable: ", value_list) from err
             self._values = parsed_values
 
     def scale_values(self, factor):

--- a/hepdata_lib/c_file_reader.py
+++ b/hepdata_lib/c_file_reader.py
@@ -1,7 +1,6 @@
 """.C file reader"""
 import io
 from array import array
-from future.utils import raise_from
 try:
     from ROOT import TGraph, TGraphErrors  # pylint: disable=no-name-in-module
 except ImportError as e:  # pragma: no cover
@@ -164,7 +163,7 @@ class CFileReader:
         try:
             t_object = TGraphErrors(length, x_values, y_values, dx_values, dy_values)
         except TypeError as err:
-            raise_from(TypeError("Invalid value in TGraphErrors constructor!"), err)
+            raise TypeError("Invalid value in TGraphErrors constructor!") from err
         graph = ru.get_graph_points(t_object)
 
         return graph
@@ -189,7 +188,7 @@ class CFileReader:
         try:
             t_object = TGraph(length, x_values, y_values)
         except TypeError as err:
-            raise_from(TypeError("Invalid value in TGraph constructor!"), err)
+            raise TypeError("Invalid value in TGraph constructor!") from err
         graph = ru.get_graph_points(t_object)
 
         return graph
@@ -279,7 +278,7 @@ class CFileReader:
                         tgraph_names.append(line.split('"', 1)[1].split('"')[0])
                     except IndexError as err:
                         tgraph_names = 'null'
-                        raise_from(IndexError("index out of range"), err)
+                        raise IndexError("index out of range") from err
                     start = 0
                     counter = 0
                 if start == 2:
@@ -287,7 +286,7 @@ class CFileReader:
                         tgrapherror_names.append(line.split('"', 1)[1].split('"')[0])
                     except IndexError as err:
                         tgrapherror_names = 'null'
-                        raise_from(IndexError("index out of range"), err)
+                        raise IndexError("index out of range") from err
                     start = 0
                     counter = 0
 
@@ -392,5 +391,5 @@ class CFileReader:
                 except ValueError:
                     values.append(float(i))
             except ValueError as err:
-                raise_from(ValueError("Value is not a number in variable:", graphname), err)
+                raise ValueError("Value is not a number in variable:", graphname) from err
         return values

--- a/hepdata_lib/root_utils.py
+++ b/hepdata_lib/root_utils.py
@@ -1,7 +1,6 @@
 """hepdata_lib utilities to interact with ROOT data formats."""
 from collections import defaultdict
 import ctypes
-from future.utils import raise_from
 import numpy as np
 try:
     import ROOT as r
@@ -114,14 +113,14 @@ class RootFileReader:
                 f"Cannot find any object in file {self.tfile} using path {path_to_object} or"
                 + " interpreting it as a TCanvas with TPads."
             )
-            raise_from(IOError(msg), err)
+            raise IOError(msg) from err
 
         except AttributeError as err:
             msg = (
                 f"Cannot find any object in file {self.tfile} using path {path_to_object} or"
                 + " interpreting it as a TCanvas with TPads."
             )
-            raise_from(IOError(msg), err)
+            raise IOError(msg) from err
 
         return None
 
@@ -246,7 +245,7 @@ class RootFileReader:
                 values.append(getattr(event, branch_name))
             except AttributeError as err:
                 msg = f"The TTree does not have a branch with name '{branch_name}'."
-                raise_from(RuntimeError(msg),err)
+                raise RuntimeError(msg) from err
         return values
 
     def read_limit_tree(self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 numpy
 PyYAML>=4.0
-future
 hist
 scipy
 hepdata-validator>=0.3.5

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -8,7 +8,6 @@ try:
     import ROOT
 except ImportError as e:
     print(f'Cannot import ROOT: {str(e)}')
-from future.utils import raise_from
 
 
 def float_compare(x_val, y_val, precision=1e-6):
@@ -100,8 +99,8 @@ def make_tmp_root_file(path_to_file='tmp_{RANDID}.root', mode="RECREATE",
         try:
             path_to_file = path_to_file.format(RANDID=get_random_id())
         except IndexError as err:
-            raise_from(IOError("String substitution failed. Your input path should not \
-                           have any braces except possibly for the {RANDID} token!"), err)
+            raise IOError("String substitution failed. Your input path should not \
+                           have any braces except possibly for the {RANDID} token!") from err
 
     rfile = ROOT.TFile(path_to_file, mode)  # pylint: disable=no-member
 


### PR DESCRIPTION
`raise ... from` is available since forever?, so no need for keeping the obsolete future module

The future package relies on 2to3, which was removed in python 3.13. We want to get rid of the future package in the LCG stacks for python 3.13

<!-- readthedocs-preview hepdata-lib start -->
----
📚 Documentation preview 📚: https://hepdata-lib--283.org.readthedocs.build/en/283/

<!-- readthedocs-preview hepdata-lib end -->